### PR TITLE
feat: rebrand to Make X Great Again — 5-pillar repositioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,111 +1,111 @@
 <div align="center">
 
-# x-spam-sentinel 🛡️
+# Make X Great Again 🛡️
 
-**AI 驱动的公益、半公开、开源 X(Twitter) 反垃圾/色情机器人系统**
-
-Browse X normally — get passively warned about spam & porn-ad bots,
-with one-click block and one-click report. Community-curated, transparent,
-forkable blocklist.
+### 让 X 重新能用 · 一个被动的 X 旁路扩展
 
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](./LICENSE)
-[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#项目状态)
+[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#状态--路线图)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![Live](https://img.shields.io/badge/live-x.zuoluo.tv-38bdf8.svg)](https://x.zuoluo.tv)
 
-🌐 **Live**：[x.zuoluo.tv](https://x.zuoluo.tv) · 📋 [公开 spam 榜单](https://x.zuoluo.tv/list) · 📦 [安装扩展](https://github.com/foru17/x-spam-sentinel/releases/latest)
+🌐 **Live**：[x.zuoluo.tv](https://x.zuoluo.tv) · 📋 [公开 spam 榜单](https://x.zuoluo.tv/list) · 📦 [安装扩展](https://github.com/foru17/make-x-great-again/releases/latest)
 
-[什么是这个](#是什么) · [怎么工作](#怎么工作) · [快速开始](#快速开始) · [架构](./docs/ARCHITECTURE.md) · [治理](./GOVERNANCE.md) · [贡献](./CONTRIBUTING.md)
+[做什么](#做什么) · [5 个支柱](#5-个支柱) · [怎么用](#怎么用) · [状态--路线图](#状态--路线图) · [架构](./docs/ARCHITECTURE.md) · [治理](./docs/GOVERNANCE.md) · [贡献](./CONTRIBUTING.md)
 
 </div>
 
 ---
 
-## 是什么
+## 做什么
 
-X 上大量新注册的垃圾广告 / 色情广告机器人刷评论和留言，严重影响正常交流。
-官方 API 太贵。本项目用 **浏览器扩展 + 本地/服务端 AI 分析 + 社区共享黑名单**
-提供一个不依赖官方 API 的解法：
+X(Twitter) 现在的问题不止于"色情/广告机器人刷评论"——它整体在变得不好用：
 
-- 🧩 **浏览器扩展**：被动检测你正在浏览页面上的可疑账号，弹窗提醒"本页发现 N 个 spam"
-- 🛑 **一键拉黑**（用户手动触发，绝不静默自动）/ 🚩 **一键上报**
-- 🧠 **AI 分类**：综合账号年龄、头像、社交图谱、内容/导流话术；新注册账号尤其严格
-- 🌐 **半公开黑名单**：中心服务库为性能真源，确认后的条目**同步到 GitHub**，
-  公开、可 fork、可审计
-- ⚖️ **治理优先**：AI 判定永不自动公开，必经人工复核；有申诉/移除通道
+- 评论区被 bot 淹没；正常讨论很难被看到
+- 想关注一个新 KOL，搞不清是真号还是营销号
+- 想知道某个账号历史上谈过什么、最热的几条是什么——只能手动翻
+- 算法决定了你看到谁，而不是反过来
 
-> 公益、开源（AGPL-3.0）。范围**严格限定** spam / 色情广告机器人，**不碰观点立场**。
+**Make X Great Again (MXGA)** 是一个**被动的、嵌进 X 浏览体验里的旁路扩展**。AI 在你正常刷 X 时静默工作，做下面 5 件事（部分已上线，其它在路上）。
 
-## 怎么工作
+完全开源（AGPL-3.0），不收集任何用户数据；公开公榜数据仅含 X 公开数字 ID。
 
-```
-你浏览 X → 扩展被动读取可见账号 → 本地启发式预筛
-   → 黑名单查询（本地 bloom / 中心 API） → 弹窗：本页 N 个可疑
-   → 你点：一键拉黑(手动手势) / 一键上报
-        → 中心服务：去重 → LLM 分类 → 人工复核闸门
-        → 同步到 GitHub 公开分片名单（版本化、CDN、可 fork）
-        → 各扩展拉取更新
-```
+## 5 个支柱
 
-完整机制见 **[docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)**。
+| # | 支柱 | 状态 | 一句话 |
+|---|---|---|---|
+| **01** | **Spam 净化** | ✅ Live | 评论区色情/广告 bot 被动检测 + 一键真·拉黑（驱动 X 自身屏蔽接口） + 公开共建黑名单 |
+| **02** | **KOL 信号分** | 🚧 Next | 鼠标停 @handle → 浮卡：账号年龄、原创比、主题集中度、互动质量 |
+| **03** | **KOL 历史摘要** | 🚧 Soon | 进 profile 页 → 自动侧栏：「主要谈 A/B/C」「本月最热 5 条」「最佳互动时段」 |
+| **04** | **社交图谱提示** | 🚧 Soon | 看推文时显示「被你关注的 3 个 KOL 转过 / 评论过」，让信号穿过算法噪声 |
+| **05** | **个人数据导出** | 🚧 Soon | 一键导出你的关注 / 收藏 / 推文为 JSON / Markdown，备份或迁出 |
 
-## 快速开始
+## 怎么用
 
-### 普通用户（即将提供）
-
-安装上架后的 Chrome 扩展即可，无需配置。当前为 alpha，请见下方开发者方式。
-
-### 开发者 / 本地 MVP
-
-本地即可跑通"扩展 + 本地服务"闭环：
+### 普通用户（Chrome）
 
 ```bash
-cp .env.example .env      # 填 LLM_BASE_URL / LLM_API_KEY / LLM_MODEL
-pnpm install
-pnpm serve                # 本地服务 http://127.0.0.1:8787
+# 即将上 Chrome Web Store；当前需要开发者模式手动加载：
+1. 从 https://github.com/foru17/make-x-great-again/releases/latest 下载 .zip
+2. 打开 chrome://extensions，开启「开发者模式」
+3. 「加载已解压的扩展程序」→ 选解压后的目录
+4. 访问 x.com 即可（扩展被动工作）
 ```
 
-然后 `chrome://extensions` → 开发者模式 → 加载已解压 → 选 `extension/` →
-刷新 x.com。详见 **[docs/MVP.md](./docs/MVP.md)**。
+完整门户：[https://x.zuoluo.tv](https://x.zuoluo.tv)（含治理铁律、实时公榜数据）
 
-校验：`pnpm typecheck && pnpm test && pnpm lint`
+### 开发者 / 本地
 
-## 项目状态
+```bash
+cp .env.example .env       # OpenAI-compatible LLM endpoint
+pnpm install
+pnpm typecheck && pnpm test && pnpm lint
 
-🟠 **Alpha** — 本地 MVP 已在真实 X 上验证（被动数字 ID 提取、自动启发式预筛、
-账号特征入模、真实色情广告 bot 命中无误杀）。中心服务 + GitHub 同步 + 公开
-扩展为规划/进行中（见 [架构](./docs/ARCHITECTURE.md) 与下方路线）。
+# 扩展
+cd extension && npx wxt build
+# → 加载 extension/.output/chrome-mv3
 
-| 模块 | 状态 |
-|---|---|
-| 本地 AI 分类器 + 私有策展库 | ✅ 已验证 |
-| MV3 扩展（被动 + 自动预筛 + 一键隐藏） | ✅ 本地可用 |
-| Cloudflare 服务 (Workers + D1 + R2 + Cron) | 🚧 规划 |
-| 报告/申诉 + 人工复核闸门 | 🚧 规划 |
-| GitHub 公开名单同步 + CDN | 🚧 规划 |
+# 边缘服务
+cd services/edge && npx wrangler dev
+# 部署：见 services/edge/DEPLOY.md
+```
+
+## 状态 / 路线图
+
+- ✅ **Wave 1-6**：MVP → WXT 重建 → Cloudflare 部署 → /admin 审核台 → 公开 landing + /list → base-ui 视觉
+- ✅ **Wave 7**：迁出公司 GitHub，启用个人域名 `x.zuoluo.tv`
+- ✅ **Wave 8**（本次）：rebrand 为 Make X Great Again，重新定位为 X 社交辅助平台
+- 🚧 **Wave 9**：Pillar 02 KOL 信号分 mini badge
+- 🚧 **Wave 10**：Pillar 03 KOL profile 摘要侧栏
+- 🚧 **Wave 11**：Pillar 04 社交图谱碎片
+- 🚧 **Wave 12**：Pillar 05 用户数据导出
 
 ## 仓库结构
 
 ```
-src/            本地/服务端分类器、策展库、本地服务
-extension/      MV3 浏览器扩展（被动 content-script）
-docs/           ARCHITECTURE.md（机制设计）· MVP.md（本地跑法）
-GOVERNANCE.md   治理红线、范围、申诉与移除
-CONTRIBUTING.md 如何参与 · SECURITY.md 安全报告
+src/                  本地 LLM 分类器 + 私有策展库（T3 spike）
+extension/            MV3 浏览器扩展（WXT + React 19 + Tailwind v4）
+services/edge/        Cloudflare Worker + D1 + SSR pages (/、/list、/admin)
+docs/
+  ARCHITECTURE.md     系统设计
+  GOVERNANCE.md       治理红线
+  PRIVACY.md          隐私承诺
+  STATUS.md           as-built audit
 ```
-
-公开**名单数据**将放在**独立仓库**，与代码解耦（数据 feed 独立版本/CI）。
 
 ## 治理与隐私（重要）
 
-这是一份对真实账号的公开指控列表。请先读 **[GOVERNANCE.md](./GOVERNANCE.md)**：
-置信度阈值 + 公开前人工复核、申诉/可审计移除、除公开数字 ID 外不存 PII、
-范围严格限定、透明版本化变更。误判申诉见
-[问题模板](./.github/ISSUE_TEMPLATE/)。
+这是一份对真实账号的公开指控列表。请先读 [docs/GOVERNANCE.md](./docs/GOVERNANCE.md)：
+
+- 置信度阈值 + 公开前人工/社区双重审核
+- 申诉/移除通道（GitHub issue + 48h 内复核）
+- 除公开数字 ID 外不存任何 PII
+- 范围严格限定 spam / 色情广告 bot，**不碰观点立场**
+- 透明版本化变更，所有决策写入 review_log
 
 ## 贡献
 
-欢迎 PR。请先读 [CONTRIBUTING.md](./CONTRIBUTING.md) 与 [GOVERNANCE.md](./GOVERNANCE.md)。
+欢迎 PR。请先读 [CONTRIBUTING.md](./CONTRIBUTING.md) 与 [docs/GOVERNANCE.md](./docs/GOVERNANCE.md)。
 安全问题请走 [SECURITY.md](./SECURITY.md)，不要开公开 issue。
 
 ## License

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -63,7 +63,7 @@ async function ghPoll(deviceCode: string) {
   const j = (await r.json()) as { access_token?: string; error?: string };
   if (!j.access_token) return { pending: j.error ?? "pending" };
   const u = await fetch("https://api.github.com/user", {
-    headers: { authorization: `Bearer ${j.access_token}`, "user-agent": "x-spam-sentinel" },
+    headers: { authorization: `Bearer ${j.access_token}`, "user-agent": "mxga" },
   });
   const user = (await u.json()) as { login?: string };
   await setGh(j.access_token, user.login ?? "github");

--- a/extension/entrypoints/options/App.tsx
+++ b/extension/entrypoints/options/App.tsx
@@ -495,7 +495,7 @@ function Settings() {
 }
 
 const About = () => (
-  <Page title="关于" sub="x-spam-sentinel · 公益、开源">
+  <Page title="关于" sub={`${BRAND.name} · 公益、开源`}>
     <div className="max-w-[680px] space-y-4 text-[13px] leading-7 text-fg-2">
       <p>
         基于 AI 的 X(Twitter) 反垃圾 / 色情机器人扩展。被动检测、本地优先、中心服务（Cloudflare）协同；用户一键拉黑即视为人工确认信号之一。
@@ -513,7 +513,7 @@ const About = () => (
             rel="noopener"
             className="mt-1 inline-block text-[13px] text-fg hover:text-accent"
           >
-            github.com/{BRAND.owner}/x-spam-sentinel ↗
+            github.com/{BRAND.owner}/make-x-great-again ↗
           </a>
         </div>
         <div className="bg-bg p-4">
@@ -581,7 +581,10 @@ export function App() {
           <span className="text-fg">
             <Shield />
           </span>
-          x-spam-sentinel
+          <span className="flex flex-col gap-px leading-tight">
+            <span>{BRAND.acronym}</span>
+            <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-fg-4">{BRAND.name}</span>
+          </span>
         </div>
         <nav className="flex flex-col gap-0.5" aria-label="管理面板导航">
           {TABS.map(([id, label]) => (

--- a/extension/entrypoints/options/index.html
+++ b/extension/entrypoints/options/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>x-spam-sentinel · 管理面板</title>
+    <title>MXGA · 管理面板</title>
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>

--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -45,7 +45,8 @@ export function App() {
         <span className="text-fg">
           <Shield />
         </span>
-        <b className="text-[14px] font-semibold tracking-[-.005em]">x-spam-sentinel</b>
+        <b className="text-[14px] font-semibold tracking-[-.005em]">{BRAND.acronym}</b>
+        <span className="text-[10.5px] font-medium uppercase tracking-[0.08em] text-fg-4">{BRAND.name}</span>
         <span
           aria-label={status === null ? "检查中" : status.ok ? "服务在线" : "服务不可达"}
           className={`ml-auto inline-flex h-2 w-2 rounded-full ${

--- a/extension/entrypoints/popup/index.html
+++ b/extension/entrypoints/popup/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>x-spam-sentinel</title>
+    <title>MXGA</title>
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>

--- a/extension/lib/brand.ts
+++ b/extension/lib/brand.ts
@@ -1,26 +1,32 @@
 // Single source of truth for the project's public identity, mirrored from
 // `services/edge/src/brand.ts`. Used by every extension entry-point + the
-// content-script so links can be moved in one place when the project changes
-// home.
+// content-script so links can be moved in one place when the project
+// changes home.
 
 export const BRAND = {
+  /** Full product name shown in title bars / hero / about. */
+  name: "Make X Great Again",
+  /** Short acronym for compact surfaces (popup header, content-script badges). */
+  acronym: "MXGA",
+  /** Single-line positioning. */
+  tagline: "让 X 重新能用 · 一个被动的 X 旁路扩展",
   /** Public GitHub repo URL (no trailing slash). */
-  repo: "https://github.com/foru17/x-spam-sentinel",
+  repo: "https://github.com/foru17/make-x-great-again",
   /** Latest GitHub Release page (auto-redirects to newest .zip). */
-  release: "https://github.com/foru17/x-spam-sentinel/releases/latest",
-  /** Public Worker base URL (custom domain). The extension can still override
-   *  this from settings for testing against localhost or staging. */
+  release: "https://github.com/foru17/make-x-great-again/releases/latest",
+  /** Public Worker base URL (custom domain). Extension can override in settings. */
   edgeBase: "https://x.zuoluo.tv",
   /** Governance doc inside the repo. */
   governance:
-    "https://github.com/foru17/x-spam-sentinel/blob/main/docs/GOVERNANCE.md",
+    "https://github.com/foru17/make-x-great-again/blob/main/docs/GOVERNANCE.md",
   /** Privacy doc inside the repo. */
-  privacy: "https://github.com/foru17/x-spam-sentinel/blob/main/docs/PRIVACY.md",
-  /** Appeal / removal request entry (used by the content-script bubble). */
+  privacy:
+    "https://github.com/foru17/make-x-great-again/blob/main/docs/PRIVACY.md",
+  /** Appeal / removal request entry (used by content-script bubble). */
   appealNewIssue:
-    "https://github.com/foru17/x-spam-sentinel/issues/new?template=appeal.yml",
+    "https://github.com/foru17/make-x-great-again/issues/new?template=appeal.yml",
   /** Generic issue tracker URL. */
-  issues: "https://github.com/foru17/x-spam-sentinel/issues",
+  issues: "https://github.com/foru17/make-x-great-again/issues",
   /** Owner display name. */
   owner: "foru17",
   /** License id. */

--- a/extension/lib/ui.ts
+++ b/extension/lib/ui.ts
@@ -184,7 +184,7 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
 
   const pill = document.createElement("button");
   pill.className = "pill";
-  pill.setAttribute("aria-label", "x-spam-sentinel 本页可疑账号");
+  pill.setAttribute("aria-label", `${BRAND.acronym} 本页可疑账号`);
 
   const card = document.createElement("div");
   card.className = "card";
@@ -219,7 +219,7 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
     if (!findings.length) {
       card.innerHTML = `
         <div class="hd">${icon("shield-check", "var(--brand)", 16)}
-          <span>x-spam-sentinel 已启用</span>
+          <span>${BRAND.acronym} 已启用</span>
           <span class="x" data-x>${icon("x", "currentColor", 14)}</span></div>
         <div class="sub" style="display:block;line-height:1.6">
           正在被动检查本页账号。发现可疑的垃圾/色情机器人时，会在这里提示并提供一键处理。</div>

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "x-spam-sentinel-extension",
+  "name": "mxga-extension",
   "version": "0.1.0",
   "private": true,
-  "description": "x-spam-sentinel browser extension (WXT, MV3, passive).",
+  "description": "Make X Great Again (MXGA) — passive ambient X browser extension (WXT, MV3).",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -1,33 +1,33 @@
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "wxt";
 
-// x-spam-sentinel — strictly passive. Only localhost host permission; no
-// X host permissions beyond the content-script match (we only read the DOM
-// already rendered for the user).
+// Make X Great Again (MXGA) — strictly passive. Only the Worker host
+// permission for our own API; X DOM is read via the content-script match.
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
   vite: () => ({ plugins: [tailwindcss()] }),
   // Don't spawn a throwaway browser profile on `wxt dev`. Load the built
-  // .output/chrome-mv3 into your own Chrome (logged into X) manually; WXT
-  // still watches + hot-reloads it.
+  // .output/chrome-mv3 into your own Chrome (logged into X) manually;
+  // WXT still watches + hot-reloads it.
   webExt: { disabled: true },
   manifest: {
-    name: "x-spam-sentinel",
+    name: "Make X Great Again",
     description:
-      "Passive AI spam / porn-bot detection for X. Public-good, open source.",
+      "Make X usable again. Passive AI: spam shield + KOL signal score + profile digest + social graph hints. Public-good, open source.",
     permissions: ["storage"],
     host_permissions: [
       // Public Worker entry point (custom domain).
       "https://x.zuoluo.tv/*",
-      // Legacy workers.dev URL — kept so installs that still have an old
-      // edgeBase setting can still talk to the Worker until they update.
+      // Legacy workers.dev URL kept as fallback for installs that still
+      // hold an old edgeBase setting; safe to drop after the user base
+      // has cycled the new release.
       "https://x-spam-sentinel-edge.zuoluotv.workers.dev/*",
       "https://github.com/*",
       "https://api.github.com/*",
       "http://127.0.0.1:8787/*",
       "http://localhost:8787/*",
     ],
-    action: { default_title: "x-spam-sentinel" },
+    action: { default_title: "Make X Great Again" },
     options_ui: { open_in_tab: true },
   },
 });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "x-spam-sentinel",
+  "name": "make-x-great-again",
   "version": "0.0.1",
   "private": true,
-  "description": "Local AI classifier + curation store for the x-spam-sentinel project (T3 spike).",
+  "description": "Make X Great Again (MXGA) — passive ambient X extension. Local classifier + curation store + shared Worker/D1.",
   "license": "AGPL-3.0-only",
   "type": "module",
   "engines": {

--- a/services/edge/src/brand.ts
+++ b/services/edge/src/brand.ts
@@ -1,25 +1,31 @@
 // Single source of truth for the project's public identity. Used by the
-// Worker SSR pages so the GitHub repo, public domain, and various deep links
-// can be moved in one place when the project changes home.
+// Worker SSR pages so the GitHub repo, public domain, and various deep
+// links can be moved in one place when the project changes home.
 //
 // Keep in sync with `extension/lib/brand.ts`.
 
 export const BRAND = {
+  /** Full product name shown in title bars / hero / about. */
+  name: "Make X Great Again",
+  /** Short acronym for compact surfaces (badges, popup header, doc cross-refs). */
+  acronym: "MXGA",
+  /** Single-line positioning. */
+  tagline: "让 X 重新能用 · 一个被动的 X 旁路扩展",
   /** Public GitHub repo URL (no trailing slash). */
-  repo: "https://github.com/foru17/x-spam-sentinel",
+  repo: "https://github.com/foru17/make-x-great-again",
   /** Latest GitHub Release page (auto-redirects to newest assets). */
-  release: "https://github.com/foru17/x-spam-sentinel/releases/latest",
+  release: "https://github.com/foru17/make-x-great-again/releases/latest",
   /** Public Worker entry point (custom domain). */
   edgeBase: "https://x.zuoluo.tv",
   /** Governance doc inside the repo. */
-  governance: "https://github.com/foru17/x-spam-sentinel/blob/main/docs/GOVERNANCE.md",
+  governance: "https://github.com/foru17/make-x-great-again/blob/main/docs/GOVERNANCE.md",
   /** Privacy doc inside the repo. */
-  privacy: "https://github.com/foru17/x-spam-sentinel/blob/main/docs/PRIVACY.md",
+  privacy: "https://github.com/foru17/make-x-great-again/blob/main/docs/PRIVACY.md",
   /** Appeal / removal request entry. */
-  appealNewIssue: "https://github.com/foru17/x-spam-sentinel/issues/new",
+  appealNewIssue: "https://github.com/foru17/make-x-great-again/issues/new",
   /** Generic issue tracker URL. */
-  issues: "https://github.com/foru17/x-spam-sentinel/issues",
-  /** Org / owner display name (shown in the footer). */
+  issues: "https://github.com/foru17/make-x-great-again/issues",
+  /** Owner display name. */
   owner: "foru17",
   /** License id. */
   license: "AGPL-3.0",

--- a/services/edge/src/index.ts
+++ b/services/edge/src/index.ts
@@ -38,7 +38,7 @@ async function ghIdentity(req: Request): Promise<string | null> {
     const r = await fetch("https://api.github.com/user", {
       headers: {
         authorization: `Bearer ${tok}`,
-        "user-agent": "x-spam-sentinel",
+        "user-agent": "mxga",
         accept: "application/vnd.github+json",
       },
     });

--- a/services/edge/src/pages/_layout.ts
+++ b/services/edge/src/pages/_layout.ts
@@ -147,7 +147,7 @@ ${o.head ?? ""}
 <style>${CSS}${o.css ?? ""}</style>
 </head><body>
 <header class="wrap nav" role="banner">
-  <a class="brand" href="/" aria-label="x-spam-sentinel 首页">${LOGO_SVG}<span>x-spam-sentinel</span></a>
+  <a class="brand" href="/" aria-label="${BRAND.name} 首页">${LOGO_SVG}<span>${BRAND.acronym}</span></a>
   <nav class="links" aria-label="主导航">
     ${navItem("list", "/list", "公榜")}
     ${navItem("github", BRAND.repo, "GitHub")}

--- a/services/edge/src/pages/admin.ts
+++ b/services/edge/src/pages/admin.ts
@@ -211,7 +211,7 @@ const SCRIPT = String.raw`
     if(!TOK){renderLocked();return}
     $('app').innerHTML=
       '<div class="bar">'
-      +'<div><h1>'+ ${JSON.stringify(LOGO_SVG)} +'<span>审核台 · 守门员</span></h1>'
+      +'<div><h1>'+ ${JSON.stringify(LOGO_SVG)} +'<span>'+ ${JSON.stringify(BRAND.acronym)} +' · 审核台 · 守门员</span></h1>'
       +'<div class="sub">仅维护者使用 · 通过 = 入公榜 · 驳回 / 移除 = 不公开 · 治理见 <a href="'+GH+'/blob/main/docs/GOVERNANCE.md" target="_blank">GOVERNANCE</a></div></div>'
       +'<div class="auth"><span class="ok">已认证</span><button class="btn sm" onclick="window.__xss.logout()">退出</button></div>'
       +'</div>'
@@ -440,7 +440,7 @@ export function adminHtml(): string {
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="color-scheme" content="dark">
 <meta name="robots" content="noindex,nofollow">
-<title>x-spam-sentinel · 审核台</title>
+<title>${BRAND.acronym} · 审核台</title>
 <style>${CSS}</style>
 </head><body>
 <div class="wrap"><div id="app" aria-live="polite"><div class="locked"><div class="card"><div class="lock"></div><h2>加载中…</h2></div></div></div></div>

--- a/services/edge/src/pages/landing.ts
+++ b/services/edge/src/pages/landing.ts
@@ -1,22 +1,23 @@
-// Product landing — public, zero-PII. base-ui inspired: monochrome canvas,
-// type-led hierarchy, accent reserved for state.
+// Product landing — public, zero-PII. Make X Great Again — passive
+// ambient extension that makes X usable: 5 pillars, only Pillar 1 (Spam
+// Shield) is shipped today; the rest are tagged Coming soon.
+// Visual: base-ui inspired — monochrome canvas, type-led hierarchy.
 import { BRAND } from "../brand";
 import { LINKS, layout } from "./_layout";
 
 const CSS = `
 /* Hero */
-.hero{padding:96px 0 72px;max-width:760px}
+.hero{padding:96px 0 72px;max-width:780px}
 .hero .eyebrow{display:inline-flex;align-items:center;gap:8px;font-size:11.5px;font-weight:600;
   letter-spacing:.14em;text-transform:uppercase;color:var(--fg-3);padding:5px 10px;
   border:1px solid var(--border);border-radius:999px;margin-bottom:24px}
 .hero .eyebrow .dot{width:6px;height:6px;border-radius:50%;background:var(--ok);
   box-shadow:0 0 0 0 rgba(16,185,129,.45);animation:pulse 2.4s ease-out infinite}
 @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(16,185,129,.45)}100%{box-shadow:0 0 0 6px rgba(16,185,129,0)}}
-.hero h1{font-size:60px;line-height:1.05;letter-spacing:-.035em;font-weight:600;
+.hero h1{font-size:64px;line-height:1.02;letter-spacing:-.04em;font-weight:600;
   margin:0 0 22px;color:var(--fg)}
-.hero h1 .em{color:var(--fg)}
-.hero h1 .sub{display:block;color:var(--fg-3);font-weight:500}
-.hero .lede{font-size:17px;color:var(--fg-2);max-width:600px;margin-bottom:32px;
+.hero h1 .sub{display:block;color:var(--fg-3);font-weight:500;letter-spacing:-.03em}
+.hero .lede{font-size:17px;color:var(--fg-2);max-width:620px;margin-bottom:32px;
   line-height:1.6;letter-spacing:-.005em}
 .hero .ctas{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:18px}
 .hero .meta{font-size:12.5px;color:var(--fg-4);display:flex;flex-wrap:wrap;
@@ -27,19 +28,25 @@ const CSS = `
 section.block{padding:64px 0;border-top:1px solid var(--border)}
 section.block h2{font-size:11.5px;letter-spacing:.18em;text-transform:uppercase;
   color:var(--fg-3);font-weight:600;margin-bottom:32px}
-section.block h2 .num{margin-right:10px;color:var(--fg-4);font-variant-numeric:tabular-nums}
 
-/* How — 4 steps in a tight grid */
-.steps{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--border);
+/* 5 Pillars — vertical stack of large cells, each labeled */
+.pillars{display:grid;grid-template-columns:1fr;gap:1px;background:var(--border);
   border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden}
-.step{padding:24px 22px;background:var(--bg);transition:background .15s}
-.step:hover{background:var(--card)}
-.step .n{font-size:11px;font-weight:600;color:var(--fg-4);font-variant-numeric:tabular-nums;
-  letter-spacing:.08em;display:block;margin-bottom:14px}
-.step h3{font-size:14.5px;font-weight:600;margin-bottom:8px;color:var(--fg);letter-spacing:-.005em}
-.step p{font-size:13px;line-height:1.6;color:var(--fg-3)}
+.pillar{display:grid;grid-template-columns:80px 1fr auto;gap:20px;padding:24px 28px;
+  background:var(--bg);align-items:center;transition:background .15s}
+.pillar:hover{background:var(--card)}
+.pillar .n{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12.5px;
+  font-weight:600;color:var(--fg-4);letter-spacing:.05em}
+.pillar .body h3{font-size:17px;font-weight:600;margin-bottom:6px;color:var(--fg);
+  letter-spacing:-.01em;display:flex;align-items:center;gap:10px}
+.pillar .body p{font-size:13.5px;line-height:1.6;color:var(--fg-3);max-width:640px}
+.pillar .status{font-size:11px;font-weight:600;padding:3px 10px;border-radius:999px;
+  border:1px solid currentColor;letter-spacing:.04em;text-transform:uppercase;white-space:nowrap}
+.pillar .status.live{color:var(--ok)}
+.pillar .status.next{color:var(--accent)}
+.pillar .status.soon{color:var(--fg-3)}
 
-/* Trust — 4 governance bullets, each with a themed glyph */
+/* Trust — 4 governance bullets, themed glyphs */
 .trust{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--border);
   border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden}
 .trust .row{display:flex;gap:14px;align-items:flex-start;padding:22px 24px;background:var(--bg);
@@ -53,12 +60,12 @@ section.block h2 .num{margin-right:10px;color:var(--fg-4);font-variant-numeric:t
 .trust .row h3{font-size:14px;font-weight:600;margin-bottom:5px;color:var(--fg);letter-spacing:-.005em}
 .trust .row p{font-size:13px;line-height:1.6;color:var(--fg-3)}
 
-/* Stats — uniform, type-led */
+/* Stats */
 .stats{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;background:var(--border);
   border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden}
 .stat{padding:24px 24px 22px;background:var(--bg)}
 .stat .n{font-size:36px;font-weight:600;letter-spacing:-.025em;font-variant-numeric:tabular-nums;
-  line-height:1.05;color:var(--fg)}
+  line-height:1.05;color:var(--fg);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
 .stat .n.skel{display:inline-block;width:64px;height:38px;background:linear-gradient(90deg,
   rgba(255,255,255,.04),rgba(255,255,255,.1),rgba(255,255,255,.04));
   background-size:200% 100%;animation:shim 1.4s ease-in-out infinite;border-radius:var(--r-sm);vertical-align:middle}
@@ -85,18 +92,18 @@ section.block h2 .num{margin-right:10px;color:var(--fg-4);font-variant-numeric:t
 @media (max-width:760px){
   .hero{padding:64px 0 48px}
   .hero h1{font-size:40px;letter-spacing:-.03em}
-  .steps{grid-template-columns:1fr 1fr}
+  .pillar{grid-template-columns:1fr;gap:8px;padding:20px}
+  .pillar .n{font-size:11px}
+  .pillar .status{align-self:flex-start;margin-top:4px}
   .trust{grid-template-columns:1fr}
-  .stats{grid-template-columns:1fr;grid-template-rows:none}
+  .stats{grid-template-columns:1fr}
   section.block{padding:48px 0}
 }
 @media (max-width:440px){
   .hero h1{font-size:34px}
-  .steps{grid-template-columns:1fr}
 }
 `;
 
-// Icons — outline, currentColor
 const ICON_DOWNLOAD = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>`;
 const ICON_GH = `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.7.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.7-5.5 6 .4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3"/></svg>`;
 const ICON_LIST = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" x2="21" y1="6" y2="6"/><line x1="8" x2="21" y1="12" y2="12"/><line x1="8" x2="21" y1="18" y2="18"/><line x1="3" x2="3.01" y1="6" y2="6"/><line x1="3" x2="3.01" y1="12" y2="12"/><line x1="3" x2="3.01" y1="18" y2="18"/></svg>`;
@@ -107,9 +114,9 @@ const ICON_USER = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" st
 
 const HERO = `
 <section class="hero">
-  <span class="eyebrow"><span class="dot" aria-hidden="true"></span>开源 · ${BRAND.license}</span>
-  <h1>X 上的垃圾与<br><span class="sub">色情机器人，到此为止。</span></h1>
-  <p class="lede">被动检测 · AI 判定 · 社区共识 · 真·拉黑。安装一次扩展，让 AI 在你浏览 X 时静默工作；只有当 3 个独立 GitHub 用户都标注同一账号时才会公开。</p>
+  <span class="eyebrow"><span class="dot" aria-hidden="true"></span>${BRAND.acronym}<span style="margin:0 8px;color:var(--fg-4)">·</span>开源 ${BRAND.license}</span>
+  <h1>${BRAND.name}<br><span class="sub">让 X 重新能用。</span></h1>
+  <p class="lede">一个被动的 X 旁路扩展。AI 在你浏览 X 时静默工作：拦下垃圾和色情机器人，给你看到的账号打信号分，总结 KOL 的历史推文。完全开源，不收集任何用户数据。</p>
   <div class="ctas">
     <a class="btn primary" href="${LINKS.RELEASE_URL}" id="installBtn" aria-label="安装到 Chrome（下载最新 Release）">${ICON_DOWNLOAD}<span>安装到 Chrome</span></a>
     <a class="btn" href="${BRAND.repo}" aria-label="在 GitHub 上查看源码">${ICON_GH}<span>GitHub</span></a>
@@ -133,14 +140,50 @@ const HERO = `
 </section>
 `;
 
-const HOW = `
+const PILLARS = `
 <section class="block">
-  <h2>它怎么工作</h2>
-  <div class="steps">
-    <div class="step"><span class="n">01</span><h3>安装扩展</h3><p>Chrome 即用，Edge 兼容。无需注册，无需配置。</p></div>
-    <div class="step"><span class="n">02</span><h3>被动检测</h3><p>仅在你刷到的账号上分析。从不主动爬取，从不代你操作。</p></div>
-    <div class="step"><span class="n">03</span><h3>社区共识</h3><p>AI 高置信判定 + 3 个独立 GitHub 用户佐证，才进公榜。</p></div>
-    <div class="step"><span class="n">04</span><h3>真·拉黑</h3><p>驱动 X 自身屏蔽接口，多端同步生效，不是本地隐藏。</p></div>
+  <h2>它做什么 · 5 件事</h2>
+  <div class="pillars">
+    <div class="pillar">
+      <div class="n">01</div>
+      <div class="body">
+        <h3>Spam 净化</h3>
+        <p>评论区的色情/广告 bot 被动检测、内联标注、一键拉黑（驱动 X 自身屏蔽接口）。AI 高置信 + ≥3 个独立 GitHub 用户共识 → 入公榜，所有人共享。</p>
+      </div>
+      <span class="status live">● Live</span>
+    </div>
+    <div class="pillar">
+      <div class="n">02</div>
+      <div class="body">
+        <h3>KOL 信号分</h3>
+        <p>鼠标停在 @handle 上 → 浮卡：账号年龄、原创比、主题集中度、互动质量、综合分。让你一眼分辨「真号 vs 营销号 vs 蹭流量」。</p>
+      </div>
+      <span class="status next">Next</span>
+    </div>
+    <div class="pillar">
+      <div class="n">03</div>
+      <div class="body">
+        <h3>KOL 历史摘要</h3>
+        <p>进入任何 X profile 页 → 自动侧栏：「这个人主要谈 A / B / C 三个话题」「本月最热的 5 条」「最佳互动时段」。给关注决策提供 30 秒判断材料。</p>
+      </div>
+      <span class="status soon">Soon</span>
+    </div>
+    <div class="pillar">
+      <div class="n">04</div>
+      <div class="body">
+        <h3>社交图谱提示</h3>
+        <p>看推文时显示「被你关注的 3 个 KOL 转过 / 评论过」「这条的真实回声范围」。让信号穿过算法噪声直达你。</p>
+      </div>
+      <span class="status soon">Soon</span>
+    </div>
+    <div class="pillar">
+      <div class="n">05</div>
+      <div class="body">
+        <h3>个人数据导出</h3>
+        <p>一键导出你自己的关注 / 收藏 / 推文为 JSON / Markdown，备份或迁出。所有数据在你浏览器内处理，不上服务端。</p>
+      </div>
+      <span class="status soon">Soon</span>
+    </div>
   </div>
 </section>
 `;
@@ -152,14 +195,14 @@ const TRUST = `
     <div class="row" style="--ic:#10b981"><span class="ic">${ICON_SHIELD}</span><div><h3>AI 单独不能自动公开</h3><p>必须人工审核 或 ≥3 个独立 GitHub 上报人共识才入公榜，红线写进 D1 状态机。</p></div></div>
     <div class="row" style="--ic:#38bdf8"><span class="ic">${ICON_LOCK}</span><div><h3>不收集 PII</h3><p>服务端只存 X 公开数字 ID 与举报人 GitHub 数字 ID；扩展端默认不上传任何浏览数据。</p></div></div>
     <div class="row" style="--ic:#f59e0b"><span class="ic">${ICON_DB}</span><div><h3>状态机锁红线</h3><p>auto_pending_review → human_confirmed 的状态转换只接受人工或社区共识，AI 触发会被路由层拒绝。</p></div></div>
-    <div class="row" style="--ic:#a855f7"><span class="ic">${ICON_USER}</span><div><h3>GitHub 登录可写</h3><p>举报与拉黑确认需 GitHub Device Flow 登录，反滥用、可追溯；不强制注册账号。</p></div></div>
+    <div class="row" style="--ic:#a855f7"><span class="ic">${ICON_USER}</span><div><h3>GitHub 登录可写</h3><p>举报、确认、上报需 GitHub Device Flow 登录，反滥用、可追溯；不强制注册账号。</p></div></div>
   </div>
 </section>
 `;
 
 const LIVE = `
 <section class="block">
-  <h2>实时透明</h2>
+  <h2>实时透明 · Pillar 1 公榜</h2>
   <div class="stats">
     <div class="stat"><div class="n" id="sCount"><span class="skel"></span></div><div class="lbl">已确认的 spam / bot 账号</div></div>
     <div class="stat"><div class="n" id="sWeek"><span class="skel"></span></div><div class="lbl">本周新增</div></div>
@@ -196,11 +239,11 @@ const SCRIPT = `
 
 export function landingHtml(): string {
   return layout({
-    title: "x-spam-sentinel · 让 AI 拦下 X 上的垃圾与色情机器人",
+    title: `${BRAND.name} · ${BRAND.tagline}`,
     current: "home",
     css: CSS,
-    head: `<meta name="description" content="开源、半公开的 X(Twitter) 反垃圾扩展。AI 判定 + 社区共识，不收集 PII，AGPL-3.0。">`,
-    body: HERO + HOW + TRUST + LIVE,
+    head: `<meta name="description" content="${BRAND.name} — 一个被动的 X(Twitter) 旁路扩展：Spam 净化 + KOL 信号分 + 摘要 + 社交图谱。开源 ${BRAND.license}，不收集 PII。">`,
+    body: HERO + PILLARS + TRUST + LIVE,
     script: SCRIPT,
   });
 }

--- a/services/edge/src/pages/list.ts
+++ b/services/edge/src/pages/list.ts
@@ -102,6 +102,7 @@ const ICON_EXT = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" str
 const SHELL = `
 <section class="head">
   <h1>公开 spam 榜单</h1>
+  <p class="lede" style="font-size:12.5px;color:var(--fg-3);margin-bottom:14px;text-transform:uppercase;letter-spacing:.12em">Pillar 01 · ${BRAND.acronym} Spam Shield</p>
   <p class="lede">最近 100 个被 AI 高置信判定 <strong>且</strong> 至少 3 个独立 GitHub 用户共识的 X 账号。除公开数字 ID 外不存任何信息。</p>
   <p class="lede">如发现误判，请提 <a href="${BRAND.appealNewIssue}" style="color:var(--accent)">申诉 issue</a>，48h 内复核移除。</p>
   <div class="pulse"><span class="dot" aria-hidden="true"></span><span id="pulseLabel">连接中…</span></div>
@@ -222,7 +223,7 @@ const SCRIPT = `
 
 export function listHtml(): string {
   return layout({
-    title: "公开 spam 榜单 · x-spam-sentinel",
+    title: `公开 spam 榜单 · ${BRAND.acronym}`,
     current: "list",
     css: CSS,
     head: `<meta name="robots" content="noindex,follow">`,


### PR DESCRIPTION
LUO-27 Wave 8 · 把项目从「公益反垃圾」rebrand 为「Make X Great Again（MXGA）— 让 X 重新能用」的 X 旁路扩展。Spam 保留为 Pillar 01，其余 4 个 pillar 标记 Next/Soon。**不动业务代码**，仅 brand surface + landing 文案。

## 改动一览

`brand.ts`（双份 mirror）+ `name` / `acronym` / `tagline` 三字段，所有 URL 翻到 `foru17/make-x-great-again`。

`landing.ts` 完整重写 5 Pillar 块（Live / Next / Soon 状态标签），CTA 不变。

`/list` lede 加 `Pillar 01 · MXGA Spam Shield` 字幕。`/admin` 标题加 MXGA prefix。

扩展 manifest name `Make X Great Again`，popup/options/content-script bubble 全部走 `BRAND.acronym` + `BRAND.name`。package 名 → `mxga-extension` / `make-x-great-again`。

README 完整重写，5-pillar 表 + roadmap (Wave 9-12)。

## 不在范围

- Worker 名 `x-spam-sentinel-edge` 留着（CF Workers 不能 in-place rename，纯 cosmetic）
- D1 db `xss-db` 留着（同上）
- Pillar 02-05 仅 landing 承诺，代码在 Wave 9+

## 验证

- `pnpm typecheck && pnpm test && pnpm lint` ✅
- `npx wxt build` 308.71 kB，manifest name `Make X Great Again`
- `wrangler deploy` version `7621fe7d`
- `curl x.zuoluo.tv` title = `Make X Great Again · 让 X 重新能用 · 一个被动的 X 旁路扩展` ✓
- `grep x-spam-sentinel` 仅历史 fallback / Worker 内部名 / package-lock（auto-regenerate）

## 关联

- 源 idea：[周报 W21](https://onenorth.feishu.cn/docx/HdLtduVTToDdGHxuQKlcy3UNnqb#KsD7dBHVOoXkcXx4mTTcTxA3n9e)
- Epic：LUO-15

🤖 Generated with [Claude Code](https://claude.com/claude-code)