### PR TITLE
feat(landing): Claude 暖调 + feed 上移到首屏 + X 图标

### DIFF
--- a/services/edge/src/pages/_layout.ts
+++ b/services/edge/src/pages/_layout.ts
@@ -11,85 +11,93 @@ import { BRAND } from "../brand";
 const GH_REPO = BRAND.repo;
 const RELEASE_URL = BRAND.release;
 
-/** Design tokens — dark mode defaults, light mode under media query, both
- *  overridable via [data-theme="light"|"dark"] on <html>. */
+/** Design tokens — Claude-inspired warm palette:
+ *  dark mode = slightly warm near-black; light mode = cream/off-white
+ *  (#fafaf7) instead of pure white; soft shadow tokens on cards instead
+ *  of bare 1px borders. Overridable via [data-theme="light"|"dark"]. */
 const CSS = `:root{
   color-scheme:dark light;
-  /* Dark mode defaults */
-  --bg:#0a0a0a;
-  --bg-2:#111113;
-  --fg:#fafafa;
-  --fg-2:#a1a1aa;
-  --fg-3:#71717a;
-  --fg-4:#52525b;
-  --border:rgba(255,255,255,.07);
-  --border-strong:rgba(255,255,255,.14);
-  --card:rgba(255,255,255,.025);
-  --card-hi:rgba(255,255,255,.05);
+  /* Dark mode defaults — warmer than pure #0a0a0a */
+  --bg:#0b0a09;
+  --bg-2:#13110f;
+  --fg:#fafaf7;
+  --fg-2:#a8a59f;
+  --fg-3:#76736d;
+  --fg-4:#56534e;
+  --border:rgba(255,250,235,.07);
+  --border-strong:rgba(255,250,235,.14);
+  --card:rgba(255,250,235,.025);
+  --card-hi:rgba(255,250,235,.055);
   --accent:#38bdf8;
-  --accent-soft:rgba(56,189,248,.12);
+  --accent-soft:rgba(56,189,248,.13);
   --danger:#ef4444;
-  --danger-soft:rgba(239,68,68,.08);
+  --danger-soft:rgba(239,68,68,.09);
   --warn:#f59e0b;
   --ok:#10b981;
   --violet:#a855f7;
-  --shadow-up:0 1px 0 rgba(255,255,255,.04) inset;
-  --grad-top:linear-gradient(180deg,rgba(56,189,248,.04),transparent 360px);
-  --r-sm:4px; --r:6px; --r-lg:10px;
+  --shadow-card:0 1px 0 rgba(255,250,235,.04) inset, 0 1px 3px rgba(0,0,0,.25);
+  --shadow-elev:0 1px 3px rgba(0,0,0,.3), 0 8px 24px -6px rgba(0,0,0,.35);
+  --grad-top:linear-gradient(180deg,rgba(56,189,248,.04),transparent 420px);
+  --r-sm:4px; --r:6px; --r-lg:10px; --r-xl:14px;
+  --font-serif:'Copernicus','Source Serif Pro',ui-serif,Georgia,'Times New Roman',serif;
 }
 
-/* Light mode — only when system says light AND user hasn't forced dark */
+/* Light mode — Claude-style warm cream, only when system says light AND
+   user hasn't forced dark */
 @media (prefers-color-scheme:light){
   :root:not([data-theme="dark"]){
     color-scheme:light;
-    --bg:#ffffff;
-    --bg-2:#f9fafb;
-    --fg:#09090b;
-    --fg-2:#3f3f46;
-    --fg-3:#71717a;
-    --fg-4:#a1a1aa;
-    --border:rgba(0,0,0,.08);
-    --border-strong:rgba(0,0,0,.18);
-    --card:rgba(0,0,0,.025);
-    --card-hi:rgba(0,0,0,.055);
+    --bg:#fafaf7;
+    --bg-2:#f3f1ec;
+    --fg:#1a1813;
+    --fg-2:#4a4640;
+    --fg-3:#807a70;
+    --fg-4:#a8a39a;
+    --border:rgba(60,50,30,.09);
+    --border-strong:rgba(60,50,30,.18);
+    --card:rgba(255,255,255,.7);
+    --card-hi:rgba(255,255,255,.95);
     --accent:#0284c7;
     --accent-soft:rgba(2,132,199,.1);
-    --danger:#dc2626;
-    --danger-soft:rgba(220,38,38,.08);
-    --warn:#d97706;
+    --danger:#b91c1c;
+    --danger-soft:rgba(185,28,28,.06);
+    --warn:#a16207;
     --ok:#15803d;
     --violet:#7e22ce;
-    --shadow-up:0 1px 0 rgba(0,0,0,.04) inset;
-    --grad-top:linear-gradient(180deg,rgba(2,132,199,.025),transparent 360px);
+    --shadow-card:0 1px 2px rgba(60,40,10,.04), 0 4px 16px -6px rgba(60,40,10,.05);
+    --shadow-elev:0 1px 3px rgba(60,40,10,.06), 0 12px 32px -10px rgba(60,40,10,.1);
+    --grad-top:linear-gradient(180deg,rgba(180,140,60,.04),transparent 420px);
   }
 }
 
 /* User force-light (regardless of system) */
 :root[data-theme="light"]{
   color-scheme:light;
-  --bg:#ffffff; --bg-2:#f9fafb; --fg:#09090b;
-  --fg-2:#3f3f46; --fg-3:#71717a; --fg-4:#a1a1aa;
-  --border:rgba(0,0,0,.08); --border-strong:rgba(0,0,0,.18);
-  --card:rgba(0,0,0,.025); --card-hi:rgba(0,0,0,.055);
+  --bg:#fafaf7; --bg-2:#f3f1ec;
+  --fg:#1a1813; --fg-2:#4a4640; --fg-3:#807a70; --fg-4:#a8a39a;
+  --border:rgba(60,50,30,.09); --border-strong:rgba(60,50,30,.18);
+  --card:rgba(255,255,255,.7); --card-hi:rgba(255,255,255,.95);
   --accent:#0284c7; --accent-soft:rgba(2,132,199,.1);
-  --danger:#dc2626; --danger-soft:rgba(220,38,38,.08);
-  --warn:#d97706; --ok:#15803d; --violet:#7e22ce;
-  --shadow-up:0 1px 0 rgba(0,0,0,.04) inset;
-  --grad-top:linear-gradient(180deg,rgba(2,132,199,.025),transparent 360px);
+  --danger:#b91c1c; --danger-soft:rgba(185,28,28,.06);
+  --warn:#a16207; --ok:#15803d; --violet:#7e22ce;
+  --shadow-card:0 1px 2px rgba(60,40,10,.04), 0 4px 16px -6px rgba(60,40,10,.05);
+  --shadow-elev:0 1px 3px rgba(60,40,10,.06), 0 12px 32px -10px rgba(60,40,10,.1);
+  --grad-top:linear-gradient(180deg,rgba(180,140,60,.04),transparent 420px);
 }
 
-/* User force-dark (regardless of system) — keep :root defaults explicitly */
+/* User force-dark (regardless of system) — explicit dark restore */
 :root[data-theme="dark"]{
   color-scheme:dark;
-  --bg:#0a0a0a; --bg-2:#111113; --fg:#fafafa;
-  --fg-2:#a1a1aa; --fg-3:#71717a; --fg-4:#52525b;
-  --border:rgba(255,255,255,.07); --border-strong:rgba(255,255,255,.14);
-  --card:rgba(255,255,255,.025); --card-hi:rgba(255,255,255,.05);
-  --accent:#38bdf8; --accent-soft:rgba(56,189,248,.12);
-  --danger:#ef4444; --danger-soft:rgba(239,68,68,.08);
+  --bg:#0b0a09; --bg-2:#13110f;
+  --fg:#fafaf7; --fg-2:#a8a59f; --fg-3:#76736d; --fg-4:#56534e;
+  --border:rgba(255,250,235,.07); --border-strong:rgba(255,250,235,.14);
+  --card:rgba(255,250,235,.025); --card-hi:rgba(255,250,235,.055);
+  --accent:#38bdf8; --accent-soft:rgba(56,189,248,.13);
+  --danger:#ef4444; --danger-soft:rgba(239,68,68,.09);
   --warn:#f59e0b; --ok:#10b981; --violet:#a855f7;
-  --shadow-up:0 1px 0 rgba(255,255,255,.04) inset;
-  --grad-top:linear-gradient(180deg,rgba(56,189,248,.04),transparent 360px);
+  --shadow-card:0 1px 0 rgba(255,250,235,.04) inset, 0 1px 3px rgba(0,0,0,.25);
+  --shadow-elev:0 1px 3px rgba(0,0,0,.3), 0 8px 24px -6px rgba(0,0,0,.35);
+  --grad-top:linear-gradient(180deg,rgba(56,189,248,.04),transparent 420px);
 }
 
 *{box-sizing:border-box;margin:0;padding:0}
@@ -147,8 +155,8 @@ a:focus-visible,button:focus-visible{border-radius:var(--r)}
 .btn.sm{padding:6px 11px;font-size:12.5px;border-radius:var(--r-sm)}
 .btn svg{width:15px;height:15px;flex-shrink:0}
 
-/* Card */
-.card{background:var(--card);border:1px solid var(--border);border-radius:var(--r-lg)}
+/* Card — soft elevation, Claude-style */
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--r-lg);box-shadow:var(--shadow-card)}
 
 /* Verdict tag */
 .tag{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;
@@ -176,7 +184,15 @@ a:focus-visible,button:focus-visible{border-radius:var(--r)}
 }
 `;
 
-const LOGO_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 4 5v6c0 5 3.4 9.4 8 11 4.6-1.6 8-6 8-11V5l-8-3Z"/><path d="m9 12 2 2 4-4"/></svg>`;
+/** X logo (the X.com / Twitter wordmark glyph) — used in brand + hero
+ *  to anchor "this is for X". Official X mark is a flat black square with
+ *  a stylised crossed X; here we render just the X stroke at currentColor
+ *  so it tints with the foreground. */
+const X_SVG = `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>`;
+const SHIELD_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 4 5v6c0 5 3.4 9.4 8 11 4.6-1.6 8-6 8-11V5l-8-3Z"/><path d="m9 12 2 2 4-4"/></svg>`;
+/** Brand mark: a shield with the X glyph nested inside — signals
+ *  "spam shield, for X". */
+const LOGO_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 4 5v6c0 5 3.4 9.4 8 11 4.6-1.6 8-6 8-11V5l-8-3Z"/><path d="M9.4 9 12 11.6 14.6 9M9.4 14.4 12 11.8 14.6 14.4" stroke-linecap="round"/></svg>`;
 const ICON_AUTO = `<svg class="icon-auto" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 3v18M12 3a9 9 0 0 1 0 18" fill="currentColor"/></svg>`;
 const ICON_LIGHT = `<svg class="icon-light" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>`;
 const ICON_DARK = `<svg class="icon-dark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z"/></svg>`;
@@ -246,3 +262,4 @@ ${o.body}
 }
 
 export const LINKS = { GH_REPO, RELEASE_URL };
+export const ICONS = { X: X_SVG, SHIELD: SHIELD_SVG };

--- a/services/edge/src/pages/landing.ts
+++ b/services/edge/src/pages/landing.ts
@@ -3,22 +3,32 @@
 // Shield) is shipped today; the rest are tagged Coming soon.
 // Visual: base-ui inspired — monochrome canvas, type-led hierarchy.
 import { BRAND } from "../brand";
-import { LINKS, layout } from "./_layout";
+import { ICONS, LINKS, layout } from "./_layout";
 
 const CSS = `
-/* Hero */
-.hero{padding:96px 0 72px;max-width:780px}
+/* Hero — Claude-inspired warm display: serif h1 for character, X glyph
+   in the eyebrow chip to anchor "this is for X" instantly */
+.hero{padding:80px 0 36px;max-width:820px}
 .hero .eyebrow{display:inline-flex;align-items:center;gap:8px;font-size:11.5px;font-weight:600;
-  letter-spacing:.14em;text-transform:uppercase;color:var(--fg-3);padding:5px 10px;
-  border:1px solid var(--border);border-radius:999px;margin-bottom:24px}
+  letter-spacing:.14em;text-transform:uppercase;color:var(--fg-2);padding:6px 12px;
+  border:1px solid var(--border-strong);border-radius:999px;margin-bottom:26px;
+  background:var(--card);box-shadow:var(--shadow-card)}
 .hero .eyebrow .dot{width:6px;height:6px;border-radius:50%;background:var(--ok);
-  box-shadow:0 0 0 0 rgba(16,185,129,.45);animation:pulse 2.4s ease-out infinite}
-@keyframes pulse{0%{box-shadow:0 0 0 0 rgba(16,185,129,.45)}100%{box-shadow:0 0 0 6px rgba(16,185,129,0)}}
-.hero h1{font-size:64px;line-height:1.02;letter-spacing:-.04em;font-weight:600;
-  margin:0 0 22px;color:var(--fg)}
-.hero h1 .sub{display:block;color:var(--fg-3);font-weight:500;letter-spacing:-.03em}
+  box-shadow:0 0 0 0 color-mix(in srgb,var(--ok) 50%,transparent);
+  animation:pulse 2.4s ease-out infinite}
+.hero .eyebrow .x{width:11px;height:11px;color:var(--fg)}
+.hero .eyebrow .sep{color:var(--fg-4);margin:0 1px}
+@keyframes pulse{0%{box-shadow:0 0 0 0 color-mix(in srgb,var(--ok) 50%,transparent)}100%{box-shadow:0 0 0 6px transparent}}
+.hero h1{font-family:var(--font-serif);font-size:68px;line-height:1.04;
+  letter-spacing:-.025em;font-weight:500;margin:0 0 22px;color:var(--fg)}
+.hero h1 .sub{display:block;color:var(--fg-3);font-weight:400;letter-spacing:-.02em;
+  font-style:italic;font-size:.85em;margin-top:4px}
+.hero h1 .xmark{display:inline-flex;width:.78em;height:.78em;vertical-align:-0.06em;
+  margin:0 .04em;color:var(--fg)}
+.hero h1 .xmark svg{width:100%;height:100%}
+.hero .eyebrow .x svg{width:100%;height:100%}
 .hero .lede{font-size:17px;color:var(--fg-2);max-width:620px;margin-bottom:32px;
-  line-height:1.6;letter-spacing:-.005em}
+  line-height:1.65;letter-spacing:-.005em}
 .hero .ctas{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:18px}
 .hero .meta{font-size:12.5px;color:var(--fg-4);display:flex;flex-wrap:wrap;
   gap:6px 14px;align-items:center}
@@ -80,9 +90,24 @@ section.block h2{font-size:11.5px;letter-spacing:.18em;text-transform:uppercase;
 .stats-foot .pip i{width:5px;height:5px;border-radius:50%;background:var(--ok);
   box-shadow:0 0 0 0 rgba(16,185,129,.55);animation:pulse 2.4s ease-out infinite}
 
-/* Live feed — most recent 10 confirmed spam, slides in from the top */
+/* FEED block — sits directly under hero, no big section header.
+   feed-head is a quiet eyebrow + "see all" link, then the feed itself. */
+.feed-block{padding:8px 0 32px;max-width:820px}
+.feed-head{display:flex;align-items:center;justify-content:space-between;gap:14px;
+  margin-bottom:12px;padding:0 2px}
+.feed-eyebrow{display:inline-flex;align-items:center;gap:8px;font-size:11px;font-weight:600;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--fg-3)}
+.feed-eyebrow .sep{color:var(--fg-4);margin:0 2px;opacity:.7}
+.feed-eyebrow .live-dot{width:6px;height:6px;border-radius:50%;background:var(--ok);
+  box-shadow:0 0 0 0 color-mix(in srgb,var(--ok) 50%,transparent);
+  animation:pulse 2.2s ease-out infinite}
+.feed-more{font-size:12.5px;color:var(--fg-2);transition:color .15s}
+.feed-more:hover{color:var(--accent)}
+
+/* Live feed — most recent 6 confirmed spam, slides in from the top */
 .feed{display:flex;flex-direction:column;gap:1px;background:var(--border);
-  border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden}
+  border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden;
+  box-shadow:var(--shadow-card)}
 .feed-row{position:relative;display:grid;grid-template-columns:28px 1fr auto auto auto;
   gap:12px;align-items:center;padding:10px 16px 10px 18px;background:var(--bg);
   transition:background .15s}
@@ -126,13 +151,7 @@ section.block h2{font-size:11.5px;letter-spacing:.18em;text-transform:uppercase;
   100%{background-position:-200% 0;opacity:0}
 }
 .feed-foot{margin-top:14px;font-size:12px;color:var(--fg-3);display:flex;
-  align-items:center;gap:10px;flex-wrap:wrap}
-.feed-foot .live{display:inline-flex;align-items:center;gap:6px}
-.feed-foot .live i{width:6px;height:6px;border-radius:50%;background:var(--ok);
-  box-shadow:0 0 0 0 color-mix(in srgb,var(--ok) 50%,transparent);
-  animation:livePulse 2.2s ease-out infinite}
-@keyframes livePulse{0%{box-shadow:0 0 0 0 color-mix(in srgb,var(--ok) 50%,transparent)}
-  100%{box-shadow:0 0 0 6px transparent}}
+  align-items:center;gap:10px;flex-wrap:wrap;padding:0 2px}
 .feed-foot strong{color:var(--fg);font-weight:600;font-variant-numeric:tabular-nums}
 .feed-foot a{color:var(--fg)}.feed-foot a:hover{color:var(--accent)}
 .feed-skel{padding:60px 20px;text-align:center;color:var(--fg-3);font-size:12.5px}
@@ -180,8 +199,12 @@ const ICON_USER = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" st
 
 const HERO = `
 <section class="hero">
-  <span class="eyebrow"><span class="dot" aria-hidden="true"></span>${BRAND.acronym}<span style="margin:0 8px;color:var(--fg-4)">·</span>开源 ${BRAND.license}</span>
-  <h1>${BRAND.name}<br><span class="sub">让 X 值得刷。</span></h1>
+  <span class="eyebrow">
+    <span class="dot" aria-hidden="true"></span>
+    <span class="x">${ICONS.X}</span>
+    ${BRAND.acronym}<span class="sep">·</span>专为 X 设计<span class="sep">·</span>开源 ${BRAND.license}
+  </span>
+  <h1>Make <span class="xmark">${ICONS.X}</span> Great Again<br><span class="sub">让 X 值得刷。</span></h1>
   <p class="lede">装上 Chrome 就能用。浏览 X 时 AI 替你拦垃圾、识水军、汇热推——无感运行，零数据上传，完全开源。</p>
   <div class="ctas">
     <a class="btn primary" href="${LINKS.RELEASE_URL}" id="installBtn" aria-label="免费装到 Chrome">${ICON_DOWNLOAD}<span>免费装到 Chrome</span></a>
@@ -266,7 +289,25 @@ const TRUST = `
 </section>
 `;
 
-const LIVE = `
+// FEED sits directly under the hero — for the "this thing is working
+// RIGHT NOW" social-proof beat. No section h2: just a quiet eyebrow that
+// chains the eye from the install CTA into the live data.
+const FEED = `
+<section class="feed-block">
+  <div class="feed-head">
+    <span class="feed-eyebrow"><i class="live-dot" aria-hidden="true"></i>实时拦下<span class="sep">·</span>20s 同步</span>
+    <a class="feed-more" href="/list">完整公榜 →</a>
+  </div>
+  <div class="feed" id="feed" role="list"><div class="feed-skel">连接中…</div></div>
+  <p class="feed-foot">
+    <span id="feedAgo">连接中…</span>
+    <span class="sep">·</span>
+    <span>本次访问看到 <strong id="feedAdded">0</strong> 条新增</span>
+  </p>
+</section>
+`;
+
+const STATS = `
 <section class="block">
   <h2>正在跑的数据，不是 PPT</h2>
   <div class="stats">
@@ -276,18 +317,6 @@ const LIVE = `
   </div>
   <p class="stats-foot">
     <span class="pip"><i aria-hidden="true"></i><span id="sAgo">60 秒同步一次</span></span>
-    <span class="sep">·</span>
-    <a href="/list">完整公榜 →</a>
-  </p>
-</section>
-
-<section class="block">
-  <h2>最近拦下的 10 个</h2>
-  <div class="feed" id="feed" role="list"><div class="feed-skel">连接中…</div></div>
-  <p class="feed-foot">
-    <span class="live"><i aria-hidden="true"></i><span id="feedAgo">实时同步</span></span>
-    <span class="sep">·</span>
-    <span>已确认 <strong id="feedAdded">0</strong> 条新增（本次会话）</span>
     <span class="sep">·</span>
     <a href="/list">完整公榜 →</a>
   </p>
@@ -375,8 +404,8 @@ const SCRIPT = `
   }
 
   function loadInitial(){
-    return fetch('/v1/list?limit=10').then(function(r){return r.json()}).then(function(j){
-      rows=(j.list||[]).slice(0,10);
+    return fetch('/v1/list?limit=6').then(function(r){return r.json()}).then(function(j){
+      rows=(j.list||[]).slice(0,6);
       latestAt=j.latestAt;
       lastPollAt=Date.now();
       renderInitial();
@@ -388,12 +417,12 @@ const SCRIPT = `
 
   function pollFeed(){
     if(!latestAt){return loadInitial()}
-    fetch('/v1/list?limit=10&since='+latestAt).then(function(r){return r.json()}).then(function(j){
+    fetch('/v1/list?limit=6&since='+latestAt).then(function(r){return r.json()}).then(function(j){
       lastPollAt=Date.now();
       var fresh=(j.list||[]).filter(function(r){return !rows.some(function(x){return key(x)===key(r)})});
       if(!fresh.length){feedAgo.textContent='无新增 · '+agoLong(lastPollAt);return}
       // Prepend new rows (newest first, animated). Cap at 10 total.
-      var added=fresh.slice(0,10);
+      var added=fresh.slice(0,6);
       latestAt=j.latestAt||latestAt;
       addedThisSession+=added.length;
       feedAddedEl.textContent=addedThisSession;
@@ -405,8 +434,8 @@ const SCRIPT = `
       });
       feedEl.insertBefore(frag,feedEl.firstChild);
       // Trim tail beyond 10
-      while(feedEl.childElementCount>10){feedEl.removeChild(feedEl.lastElementChild)}
-      rows=added.concat(rows).slice(0,10);
+      while(feedEl.childElementCount>6){feedEl.removeChild(feedEl.lastElementChild)}
+      rows=added.concat(rows).slice(0,6);
       feedAgo.innerHTML='<strong>+'+added.length+' 新</strong> · '+agoLong(lastPollAt);
     }).catch(function(){feedAgo.textContent='网络错误 · '+agoLong(lastPollAt)})
   }
@@ -427,7 +456,7 @@ export function landingHtml(): string {
     current: "home",
     css: CSS,
     head: `<meta name="description" content="${BRAND.name} — 一个被动的 X(Twitter) 旁路扩展：Spam 净化 + KOL 信号分 + 摘要 + 社交图谱。开源 ${BRAND.license}，不收集 PII。">`,
-    body: HERO + PILLARS + TRUST + LIVE,
+    body: HERO + FEED + PILLARS + TRUST + STATS,
     script: SCRIPT,
   });
 }


### PR DESCRIPTION
[LUO-30](https://github.com/foru17/make-x-great-again/issues) Wave 9.6

## 改动 3 件

### 1. Feed 上移到首屏（社会证明前置）

body 顺序：HERO → **FEED** → PILLARS → TRUST → STATS → Footer

Feed 不带 section h2，只一个低调 '● 实时拦下 · 20s 同步' eyebrow + tight 6 行（之前 10 行）。普通 viewport 安装 CTA 之后能直接看到「它现在正在干活」。

### 2. Claude 暖调

| | light | dark |
|---|---|---|
| bg | `#fafaf7` cream | `#0b0a09` 暖近黑 |
| border | warm 30°h | warm 50°h |
| cards | 白卡 + 软阴影 | 玻璃 + 内 inset |

新增 shadow token `--shadow-card` (1px subtle) + `--shadow-elev` (12px lift)，所有 .card 用阴影替代纯 1px border。

### 3. X 图标

新增 `ICONS.X` (X wordmark glyph) + `ICONS.SHIELD`。
- eyebrow chip: `● ✕ MXGA · 专为 X 设计 · 开源 AGPL-3.0`
- hero h1: `Make <X glyph> Great Again` —— X 字母换成真正的 X 图标
- brand logo 改成 shield 套 X 双划

### Typography

加 `--font-serif` token (Copernicus → Source Serif Pro → Georgia)，hero h1 切 serif，font-weight 500，letter-spacing -.025em，sub-line italic — Claude 风的 display style。

## 验证

- pnpm typecheck + biome check ✅
- Worker deploy version `3cc5aed9`
- 截图 `.screens/71-landing-claude-light-fresh.png` / `72-landing-claude-dark.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)