### PR TITLE
fix: queue noise — L1 client age short-circuit + L2 server legit-cache

### DIFF
--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -441,12 +441,28 @@ export default defineContentScript({
         }
       }
 
-      // 3 + 4. New account → LLM (reply section: every replier; elsewhere only
-      //        heuristic-positive). In-flight + budget guard cost.
+      // 3 + 4. New account → LLM. Reply section lowers the heuristic
+      //        threshold but never bypasses it — old established accounts
+      //        with no promo language are short-circuited as likely-legit
+      //        WITHOUT spending an LLM call. This is the core fix for the
+      //        admin queue being flooded with established accounts that
+      //        happened to appear in reply zones (LUO-32 / Wave 11).
       if (inflight.has(key)) return;
       const h = heuristic(sig);
-      const wantAuto =
-        h.score >= AUTO_THRESHOLD || (settings.replyAuto && isReplyContext());
+      // Implicit trust: account > 2y old AND heuristic finds nothing
+      // suspicious (score < 0.15 = no promo/link/random handle / no low
+      // followers). Skip the LLM entirely; treat as quietly-clean.
+      const ageDays = sig.accountAgeDays;
+      const isEstablished = typeof ageDays === "number" && ageDays > 730;
+      if (isEstablished && h.score < 0.15) {
+        badgeFor(anchor, key, sig, null); // looks legit, manual check still available
+        return;
+      }
+      // Reply context lowers the bar (catches subtle bots in replies) but
+      // still honors heuristic; main timeline keeps the stricter 0.5.
+      const threshold =
+        settings.replyAuto && isReplyContext() ? 0.25 : AUTO_THRESHOLD;
+      const wantAuto = h.score >= threshold;
       if (!wantAuto) {
         badgeFor(anchor, key, sig, null); // clean-looking → manual check
         return;

--- a/services/edge/src/index.ts
+++ b/services/edge/src/index.ts
@@ -218,13 +218,23 @@ app.post("/v1/classify", async (c) => {
   }
   const verdict = await classify(c.env, s);
   const now = Date.now();
+  // LUO-32 Wave 11 L2: high-confidence legit verdicts are cached but kept
+  // out of the maintainer queue. /admin/queue still only selects
+  // status='auto_pending_review', so auto_legit rows are invisible there
+  // but the next /v1/classify hit still gets a free cache return.
+  const writeStatus =
+    verdict.label === "legit" && verdict.confidence >= 0.85 ? "auto_legit" : "auto_pending_review";
   await c.env.DB.prepare(
     `INSERT INTO accounts (x_user_id,handle,display_name,avatar_url,verdict_label,confidence,reasons,model,status,source,signals_hash,first_seen,last_scored)
-     VALUES (?,?,?,?,?,?,?,?, 'auto_pending_review','auto_scan', ?, ?, ?)
+     VALUES (?,?,?,?,?,?,?,?, ?,'auto_scan', ?, ?, ?)
      ON CONFLICT(x_user_id,handle) DO UPDATE SET
        verdict_label=excluded.verdict_label, confidence=excluded.confidence, reasons=excluded.reasons,
        model=excluded.model, signals_hash=excluded.signals_hash, last_scored=excluded.last_scored,
-       avatar_url=COALESCE(excluded.avatar_url, accounts.avatar_url)`,
+       avatar_url=COALESCE(excluded.avatar_url, accounts.avatar_url),
+       status=CASE
+                WHEN accounts.status IN ('human_confirmed','rejected','removed') THEN accounts.status
+                ELSE excluded.status
+              END`,
   )
     .bind(
       uid,
@@ -235,12 +245,13 @@ app.post("/v1/classify", async (c) => {
       verdict.confidence,
       JSON.stringify(verdict.reasons),
       c.env.LLM_API_MODEL,
+      writeStatus,
       h,
       now,
       now,
     )
     .run();
-  return c.json({ cached: false, record: { verdict, status: "auto_pending_review" } });
+  return c.json({ cached: false, record: { verdict, status: writeStatus } });
 });
 
 /**


### PR DESCRIPTION
Wave 11 — 治审核队列被 legit 老号刷屏的根因。

## 两层修复

### L1 客户端 (`extension/entrypoints/content.ts`)

**根因**：评论区强制全员 LLM，绕过启发式年龄减分。

**修复**：
- 加隐式 trust 短路：`accountAgeDays > 730` AND `heuristic score < 0.15` → 不调 LLM
- 评论区 threshold 从「无脑全员」改成「降到 0.25」（仍尊重启发式）
- 主时间线保持 0.5

### L2 服务端 (`services/edge/src/index.ts /v1/classify`)

**根因**：所有 verdict 写 `auto_pending_review` 进队列。

**修复**：
- `legit AND confidence >= 0.85` → 写 `auto_legit`（新状态，进缓存不进队列）
- `/admin` queue 选 `auto_pending_review`，`auto_legit` 自动隐身
- ON CONFLICT 新加 status 守卫：`human_confirmed/rejected/removed` 不被 AI 覆盖

### D1 一次性清理（已对线上库执行）

```sql
UPDATE accounts SET status='auto_legit'
 WHERE status='auto_pending_review'
   AND verdict_label='legit' AND confidence >= 0.85;
-- 327 rows moved
```

队列对比：

| | before | after |
|---|---|---|
| 总数 | 560 | **233** (-58%) |
| legit | 461 | 134（<0.85 留下手动审） |
| spam/porn/likely/uncertain | 99 | 99（不动）|

## 决策（用户已拍）

- 老号阈值 = **730 天**
- legit 短路门槛 = **0.85**

## 验证

- pnpm typecheck + test + lint ✅
- npx wxt build ✅
- Worker version `fb3e6ee4` 已部署

🤖 Generated with [Claude Code](https://claude.com/claude-code)