### PR TITLE
chore: surface Chrome Web Store launch on landing + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 </p>
 
 <p align="center">
+  <a href="https://chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea"><img src="https://img.shields.io/chrome-web-store/v/aeoldnecphbkkckeedfgfcdcekkljdea?style=flat-square&color=4285F4&label=chrome%20web%20store&logo=googlechrome&logoColor=white" alt="Chrome Web Store"></a>
   <a href="https://github.com/foru17/make-x-great-again/blob/main/LICENSE"><img src="https://img.shields.io/github/license/foru17/make-x-great-again?style=flat-square&color=green" alt="License: AGPL-3.0"></a>
   <a href="https://github.com/foru17/make-x-great-again/releases/latest"><img src="https://img.shields.io/github/v/release/foru17/make-x-great-again?style=flat-square&color=blue&include_prereleases&label=release" alt="Release"></a>
   <a href="https://github.com/foru17/make-x-great-again/stargazers"><img src="https://img.shields.io/github/stars/foru17/make-x-great-again?style=flat-square&color=yellow" alt="Stars"></a>
@@ -20,9 +21,10 @@
 </p>
 
 <p align="center">
+  <a href="https://chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea">🟦 从 Chrome 商店安装</a> ·
   <a href="https://x.zuoluo.tv">🌐 官网门户</a> ·
   <a href="https://x.zuoluo.tv/list">📋 公共名单</a> ·
-  <a href="https://github.com/foru17/make-x-great-again/releases/latest">📦 安装扩展</a>
+  <a href="https://github.com/foru17/make-x-great-again/releases/latest">📦 GitHub Release</a>
 </p>
 
 ---
@@ -69,13 +71,23 @@ X 现在的问题，大家都知道：
 
 ### 普通用户
 
+**推荐**：直接从 Chrome Web Store 安装。
+
+👉 [chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea](https://chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea)
+
+装好后，访问 x.com 扩展会自动开始工作。
+
+<details>
+<summary>用 Edge / Brave / Arc，或想跑开发版？</summary>
+
 ```bash
-# Chrome Web Store 还在审核，当前需要开发者模式手动加载：
-# 1. 从 https://github.com/foru17/make-x-great-again/releases/latest 下载 .zip
+# 1. 从 https://github.com/foru17/make-x-great-again/releases/latest 下载最新 .zip 并解压
 # 2. chrome://extensions → 开启「开发者模式」
 # 3. 「加载已解压的扩展程序」→ 选择解压目录
 # 4. 访问 x.com，扩展自动开始工作
 ```
+
+</details>
 
 ### 开发者
 

--- a/docs/CWS_LISTING.md
+++ b/docs/CWS_LISTING.md
@@ -3,6 +3,10 @@
 > **目的**：上架 MXGA 浏览器扩展。本文档把上架需要填的所有字段集中放好，
 > 复制粘贴即可。涉及合规风险点也明确标出。
 
+> ✅ **已上架** —— [`chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea`](https://chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea)。
+> 本文档保留作为后续更新（新版本提交、字段调整、被驳回重提）的参考底稿。
+> 任何字段改动以 Chrome Web Store Developer Dashboard 的实际状态为准。
+
 ---
 
 ## 1. 基本信息
@@ -122,15 +126,25 @@ https://github.com/foru17/make-x-great-again/blob/main/docs/PRIVACY.md
 | auto-publish 路径已关 — 没有"3 人举报自动公榜"的滥用入口 | — | 这是 alpha 阶段加固，给审核员讲故事时正面提及 |
 | 服务端 LLM 供应商不在仓库 | — | 写明在 `services/edge/src/index.ts` Env interface 注释里；隐私声明也说明了 |
 
-## 8. 上架前 checklist
+## 8. 上架前 checklist（已完成 ✅）
 
-- [ ] 用 `pnpm zip` 出 production .zip（在 `.output/chrome-mv3-0.2.0.zip`）
-- [ ] 在干净 Chrome profile 加载该 zip 解压目录，跑一遍：
-  - [ ] popup 打开正常、登录引导显示
-  - [ ] 进 x.com → 看到气泡 pill「守护中」/「已扫 N」
-  - [ ] 进 https://x.com/imwsl90/status/2058805164749050313（有 spam 的 thread） → 看到 badge + 气泡列表
-  - [ ] 点单条「拉黑」 → 真的调起 X 屏蔽确认 → 完成
-  - [ ] options 页 → GitHub 登录 → Device Flow 跑通
-- [ ] 截图 5 张
-- [ ] 准备好商店付款（一次性 $5 注册费，如果还没付）
-- [ ] 提交后等审核：通常 1-3 天，敏感品类（X / Twitter 相关）可能 7-14 天
+- [x] 用 `pnpm zip` 出 production .zip（在 `.output/chrome-mv3-0.2.0.zip`）
+- [x] 在干净 Chrome profile 加载该 zip 解压目录，跑一遍：
+  - [x] popup 打开正常、登录引导显示
+  - [x] 进 x.com → 看到气泡 pill「守护中」/「已扫 N」
+  - [x] 进 https://x.com/imwsl90/status/2058805164749050313（有 spam 的 thread） → 看到 badge + 气泡列表
+  - [x] 点单条「拉黑」 → 真的调起 X 屏蔽确认 → 完成
+  - [x] options 页 → GitHub 登录 → Device Flow 跑通
+- [x] 截图 5 张
+- [x] 准备好商店付款（一次性 $5 注册费）
+- [x] 提交并通过审核
+
+## 9. 后续版本更新流程
+
+1. 把新版本号写进 `extension/package.json` + `extension/wxt.config.ts` 的 `manifest.version`
+2. `cd extension && pnpm zip` 出新的 .zip
+3. 登录 [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole/)，找到 MXGA item
+4. 「Package → Upload new package」，把 zip 拖进去
+5. 如果 listing 文案 / 截图 / 权限有变，同步更新本文档第 1–7 节并保存
+6. 提交审核（通常 1–3 天；敏感品类可能 7–14 天）
+7. 通过后同步把 GitHub Release 也打一份，让两边版本号一致

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -76,7 +76,7 @@ Wrangler 4 · @cloudflare/workers-types · @types/chrome。
   Secrets：`LLM_API_BASE` / `LLM_API_MODEL` / `LLM_API_KEY` / `ADMIN_TOKEN`。
 - GitHub 登录用于上报和防滥用计数；上线前后需要持续确认鉴权和限流配置。
 - 审核台：`/admin`（ADMIN_TOKEN 进入）。
-- 扩展通过 release zip 或 Chrome Web Store 版本分发。
+- 扩展主分发渠道：[Chrome Web Store](https://chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea)；GitHub Release zip 作为非-Chrome 浏览器和开发版的备用通道。
 
 ## 7. 安全/治理姿态
 

--- a/extension/lib/brand.ts
+++ b/extension/lib/brand.ts
@@ -14,6 +14,9 @@ export const BRAND = {
   repo: "https://github.com/foru17/make-x-great-again",
   /** Latest GitHub Release page (auto-redirects to newest .zip). */
   release: "https://github.com/foru17/make-x-great-again/releases/latest",
+  /** Chrome Web Store listing — the primary install path for normal users. */
+  chromeWebStore:
+    "https://chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea",
   /** Public Worker base URL (custom domain). Extension can override in settings. */
   edgeBase: "https://x.zuoluo.tv",
   /** Governance doc inside the repo. */

--- a/services/edge/src/brand.ts
+++ b/services/edge/src/brand.ts
@@ -15,6 +15,9 @@ export const BRAND = {
   repo: "https://github.com/foru17/make-x-great-again",
   /** Latest GitHub Release page (auto-redirects to newest assets). */
   release: "https://github.com/foru17/make-x-great-again/releases/latest",
+  /** Chrome Web Store listing — the primary install path for normal users. */
+  chromeWebStore:
+    "https://chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea",
   /** Public Worker entry point (custom domain). */
   edgeBase: "https://x.zuoluo.tv",
   /** Governance doc inside the repo. */

--- a/services/edge/src/pages/landing.ts
+++ b/services/edge/src/pages/landing.ts
@@ -218,16 +218,26 @@ section.block h2{font-size:11.5px;letter-spacing:.18em;text-transform:uppercase;
   .feed-row .x-link{display:none}
 }
 
-/* Install helper popover */
-.install-note{margin-top:20px;font-size:13px;color:var(--fg-2);
-  background:var(--card);border:1px solid var(--border);border-radius:var(--r);
-  padding:14px 18px;max-width:560px;display:none;line-height:1.65}
-.install-note.open{display:block;animation:slideIn .2s ease-out}
-@keyframes slideIn{from{opacity:0;transform:translateY(-3px)}to{opacity:1;transform:none}}
-.install-note ol{margin:8px 0 0 20px}
-.install-note li{margin:5px 0;color:var(--fg-2)}
-.install-note code{background:var(--card-hi);padding:1px 6px;border-radius:var(--r-sm);
+/* Install helper — disclosure for non-Chrome browsers / dev builds.
+   Lives below the hero meta as a quiet, collapsed-by-default <details>. */
+.install-alt{margin-top:18px;max-width:560px;font-size:12.5px;color:var(--fg-3);
+  border:1px solid var(--border);border-radius:var(--r);background:var(--card);
+  padding:0 14px}
+.install-alt summary{cursor:pointer;padding:11px 0;list-style:none;color:var(--fg-2);
+  display:flex;align-items:center;gap:8px;font-weight:500}
+.install-alt summary::-webkit-details-marker{display:none}
+.install-alt summary::before{content:"›";display:inline-block;color:var(--fg-4);
+  font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:14px;
+  transition:transform .15s;width:10px;text-align:center}
+.install-alt[open] summary::before{transform:rotate(90deg)}
+.install-alt[open] summary{border-bottom:1px solid var(--border);margin-bottom:10px}
+.install-alt ol{margin:6px 0 12px 22px;line-height:1.7}
+.install-alt li{color:var(--fg-2);margin:3px 0}
+.install-alt code{background:var(--card-hi);padding:1px 6px;border-radius:var(--r-sm);
   font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;color:var(--fg)}
+.install-alt a{color:var(--fg);text-decoration:underline;text-decoration-color:var(--border-strong);
+  text-underline-offset:2px}
+.install-alt a:hover{color:var(--accent)}
 
 @media (max-width:760px){
   .hero{padding:0}
@@ -261,7 +271,11 @@ section.block h2{font-size:11.5px;letter-spacing:.18em;text-transform:uppercase;
 }
 `;
 
-const ICON_DOWNLOAD = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>`;
+// Lucide-style Chrome glyph: outer circle + inner circle + three spokes.
+// Monochrome stroke to match the rest of the design system; we don't use the
+// brand multi-color disc on this surface because it'd clash with our type-led
+// hierarchy. The official CWS page is the user's visual confirmation of brand.
+const ICON_CHROME = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="4"/><line x1="21.17" y1="8" x2="12" y2="8"/><line x1="3.95" y1="6.06" x2="8.54" y2="14"/><line x1="10.88" y1="21.94" x2="15.46" y2="14"/></svg>`;
 const ICON_GH = `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.7.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.7-5.5 6 .4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3"/></svg>`;
 const ICON_LIST = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" x2="21" y1="6" y2="6"/><line x1="8" x2="21" y1="12" y2="12"/><line x1="8" x2="21" y1="18" y2="18"/><line x1="3" x2="3.01" y1="6" y2="6"/><line x1="3" x2="3.01" y1="12" y2="12"/><line x1="3" x2="3.01" y1="18" y2="18"/></svg>`;
 const ICON_SHIELD = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z"/></svg>`;
@@ -293,24 +307,25 @@ const HERO = `
   <h1>Make <span class="xmark">${ICONS.X}</span> Great Again<br><span class="sub">少看垃圾，多看人话。</span></h1>
   <p class="lede">广告号、色情引流先标出；拉黑由你确认。</p>
   <div class="ctas">
-    <a class="btn primary" href="${LINKS.RELEASE_URL}" id="installBtn" aria-label="下载扩展">${ICON_DOWNLOAD}<span>下载扩展</span></a>
-    <a class="btn" href="${BRAND.repo}" aria-label="在 GitHub 上查看源码">${ICON_GH}<span>看源码</span></a>
+    <a class="btn primary" href="${BRAND.chromeWebStore}" target="_blank" rel="noopener" aria-label="从 Chrome Web Store 安装扩展">${ICON_CHROME}<span>从 Chrome 商店安装</span></a>
     <a class="btn" href="/list" aria-label="看公开名单">${ICON_LIST}<span>看公开名单</span></a>
+    <a class="btn" href="${BRAND.repo}" aria-label="在 GitHub 上查看源码">${ICON_GH}<span>看源码</span></a>
   </div>
   <p class="meta">
+    <span>已上架 Chrome Web Store</span><span class="dot" aria-hidden="true"></span>
     <span>手动拉黑</span><span class="dot" aria-hidden="true"></span>
     <span>不存身份</span><span class="dot" aria-hidden="true"></span>
     <span>开源</span>
   </p>
-  <div class="install-note" id="installNote" role="status">
-    <strong>商店审核中，先手动安装</strong>：
+  <details class="install-alt">
+    <summary>用 Edge / Brave / Arc，或想跑开发版？</summary>
     <ol>
-      <li>下载解压最新 <code>.zip</code></li>
+      <li>从 <a href="${LINKS.RELEASE_URL}" target="_blank" rel="noopener">GitHub Release</a> 下载最新 <code>.zip</code> 并解压</li>
       <li>打开 <code>chrome://extensions</code>，开启「开发者模式」</li>
       <li>点「加载已解压的扩展程序」</li>
       <li>打开 x.com 就能用</li>
     </ol>
-  </div>
+  </details>
 </div>
 <div class="hero-side">
   <div class="hero-mascot" aria-hidden="true">
@@ -402,8 +417,6 @@ const FEED = `
 const SCRIPT = `
 (function(){
   var reduced=matchMedia('(prefers-reduced-motion: reduce)').matches;
-  var btn=document.getElementById('installBtn'),note=document.getElementById('installNote');
-  if(btn&&note){btn.addEventListener('click',function(e){if(!note.classList.contains('open')){e.preventDefault();note.classList.add('open');setTimeout(function(){window.location=btn.href},900)}})}
 
   function esc(s){return (s==null?'':String(s)).replace(/[&<>"']/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]})}
   function fmt(n){return typeof n==='number'?n.toLocaleString('zh-CN'):'—'}


### PR DESCRIPTION
## 背景

MXGA 已通过 Chrome Web Store 审核并上架：
👉 https://chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea

首页、README、CWS_LISTING 文档里仍写着「商店审核中，请手动 sideload」，需要统一切到官方渠道为主、sideload 降级为备用。

## 本次改动

- `services/edge/src/brand.ts` + `extension/lib/brand.ts`：新增 `chromeWebStore` 字段作为 single source of truth（mirror 同步两边）
- `services/edge/src/pages/landing.ts`：
  - 主 CTA 换成「从 Chrome 商店安装」（Lucide chrome 单色 stroke 图标，配合 base-ui design token）
  - GitHub Release sideload 步骤下放进 `<details>` 折叠区，留给 Edge/Brave/Arc/dev 版用户
  - 移除旧的「商店审核中」浮层 + 相关 JS
  - hero meta 加「已上架 Chrome Web Store」chip
- `README.md`：加 CWS 版本 shields.io badge，安装段落改为商店直链为主、sideload 进 `<details>`
- `docs/CWS_LISTING.md`：顶部 ✅ 已上架 notice + 商店 URL；§8 checklist 全打勾；新增 §9「后续版本更新流程」
- `docs/STATUS.md`：把"release zip 或 CWS"改为"CWS 主分发，zip 备用"

## 测试验证

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (6/6)
- `cd extension && pnpm compile` ✅

## 风险与回滚

- **对线上扩展的影响**：`extension/lib/brand.ts` 仅新增一个 readonly 字段 `chromeWebStore`，扩展代码内无任何引用，纯增量。当前已经分发的扩展不重打包就完全不会被发出去，下次自然构建也只是 bundle 多一个字符串常量
- **Worker 端**：landing 页面 SSR 改动，回滚仅需 `wrangler rollback`
- **D1 / Secrets / 域名**：无变化

## 关联 Issue

无独立 issue —— 由 CWS 上架触发的同步更新。