### PR TITLE
chore(d1): identity-cleanup migration — collapse handle-only duplicates

### DIFF
--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,0 +1,43 @@
+# D1 migrations ledger
+
+This file tracks one-off SQL data migrations applied to the production
+`xss-db` D1 database. Schema-level changes still live in
+[`services/edge/schema.sql`](../services/edge/schema.sql) (idempotent
+`CREATE IF NOT EXISTS` shape); migrations here are for *data* — backfills,
+de-duplications, and one-shot fixups that cannot be expressed as schema.
+
+## How to apply
+
+```bash
+cd services/edge
+
+# 1. Dry run against your local sqlite copy (recommended)
+npx wrangler d1 execute xss-db --local --file=./migrations/<file>.sql
+
+# 2. Preview against remote — the file's PREVIEW comment block has the
+#    diagnostic SELECTs to run via --command first
+npx wrangler d1 execute xss-db --remote --command="SELECT ..."
+
+# 3. Apply for real (every statement runs as one atomic D1 batch)
+npx wrangler d1 execute xss-db --remote --file=./migrations/<file>.sql
+```
+
+Every migration must:
+- Be idempotent (re-running is a no-op once the cleanup landed)
+- Write a `review_log` entry per affected row (audit trail, also makes
+  rollback possible). When the rollback needs to pair each accounts row
+  back to its specific audit entry, embed `rowid=<n>;` in the note and
+  end the note with `prior_status=...; prior_source=...` so a single
+  substr/instr parser handles both fields.
+- Ship a companion `.rollback.sql` that undoes the data change.
+- Be verified end-to-end against a `--local` seed before `--remote` apply
+  (seed → migrate → rollback → cmp against seed snapshot)
+
+## Ledger
+
+| Date | File | Affected | Notes |
+|---|---|---|---|
+| 2026-05-26 | `2026-05-26-identity-cleanup.sql` | accounts: 80 + ~34 rows → `status='removed'`; reports: 9 rows deleted | Collapses handle-only "ghost" rows that have a uid-bearing twin; deduplicates pure-orphan handles by `last_scored`; deletes report duplicates that snuck past the UNIQUE INDEX via NULL uids |
+
+Rollback: `2026-05-26-identity-cleanup.rollback.sql` (restores the
+`accounts` rows; `reports` deletes are not recoverable from migration data).

--- a/services/edge/migrations/2026-05-26-identity-cleanup.rollback.sql
+++ b/services/edge/migrations/2026-05-26-identity-cleanup.rollback.sql
@@ -1,0 +1,138 @@
+-- ============================================================================
+-- Roll back the 2026-05-26 identity cleanup
+-- ============================================================================
+-- Reverses the data changes from 2026-05-26-identity-cleanup.sql by pairing
+-- each affected accounts row to its specific review_log entry via the
+-- `rowid=<n>;` token embedded in the audit note. We match via instr() rather
+-- than dynamic LIKE because SQLite refuses LIKE patterns that concat column
+-- values ("LIKE or GLOB pattern too complex" SQLITE_ERROR).
+--
+-- review_log note layout (terminal segments, parsed by substr/instr):
+--   '...; prior_status=<status>; prior_source=<source>'
+-- prior_status is the substring between 'prior_status=' and '; prior_source='.
+-- prior_source is the substring after 'prior_source=' to end-of-note.
+--
+-- Phases (mirror-reversed from the forward migration):
+--   Phase 1 — undo Class B (pure-orphan dedup)
+--   Phase 2 — undo Class A (handle-only collapse to uid-twin)
+--   Phase 3 — undo A0b (human_confirmed promotion of uid'd twin)
+--   Phase 4 — undo A0a (whitelisted promotion of uid'd twin) — LOSSY
+--
+-- Limitations:
+--   * Class C (reports DELETEs) are NOT reversible from this migration alone.
+--   * A0a (whitelisted promotion) overwrote the uid'd row's verdict_label,
+--     confidence, reasons, signals_hash with whitelist defaults. Rollback
+--     restores status + source only — original verdict / reasons stay lost.
+--   * Once normal traffic resumes after the forward migration, ongoing scans
+--     will mutate `last_scored` and possibly statuses, making rollback
+--     increasingly imprecise. Clean rollback window: minutes, not days.
+-- ============================================================================
+
+-- ----- Phase 1 — undo Class B (pure-orphan dedup)
+UPDATE accounts
+   SET status = (
+         SELECT substr(rl.note,
+                       instr(rl.note, 'prior_status=') + 13,
+                       instr(rl.note, '; prior_source=') - instr(rl.note, 'prior_status=') - 13)
+           FROM review_log rl
+          WHERE rl.action = 'dedup_merged'
+            AND rl.actor = 'migration:2026-05-26'
+            AND instr(rl.note, 'pure-orphan cluster; rowid=' || accounts.rowid || ';') > 0
+          ORDER BY rl.at DESC LIMIT 1
+       ),
+       source = (
+         SELECT substr(rl.note, instr(rl.note, 'prior_source=') + 13)
+           FROM review_log rl
+          WHERE rl.action = 'dedup_merged'
+            AND rl.actor = 'migration:2026-05-26'
+            AND instr(rl.note, 'pure-orphan cluster; rowid=' || accounts.rowid || ';') > 0
+          ORDER BY rl.at DESC LIMIT 1
+       )
+ WHERE x_user_id IS NULL
+   AND source = 'migration:null_dedup_keep_latest';
+
+-- ----- Phase 2 — undo Class A (handle-only collapse to uid-twin)
+UPDATE accounts
+   SET status = (
+         SELECT substr(rl.note,
+                       instr(rl.note, 'prior_status=') + 13,
+                       instr(rl.note, '; prior_source=') - instr(rl.note, 'prior_status=') - 13)
+           FROM review_log rl
+          WHERE rl.action = 'dedup_merged'
+            AND rl.actor = 'migration:2026-05-26'
+            AND instr(rl.note, 'collapsed handle-only row; rowid=' || accounts.rowid || ';') > 0
+          ORDER BY rl.at DESC LIMIT 1
+       ),
+       source = (
+         SELECT substr(rl.note, instr(rl.note, 'prior_source=') + 13)
+           FROM review_log rl
+          WHERE rl.action = 'dedup_merged'
+            AND rl.actor = 'migration:2026-05-26'
+            AND instr(rl.note, 'collapsed handle-only row; rowid=' || accounts.rowid || ';') > 0
+          ORDER BY rl.at DESC LIMIT 1
+       ),
+       published_at = CASE
+                        WHEN (
+                          SELECT substr(rl.note,
+                                        instr(rl.note, 'prior_status=') + 13,
+                                        instr(rl.note, '; prior_source=') - instr(rl.note, 'prior_status=') - 13)
+                            FROM review_log rl
+                           WHERE rl.action = 'dedup_merged'
+                             AND rl.actor = 'migration:2026-05-26'
+                             AND instr(rl.note, 'collapsed handle-only row; rowid=' || accounts.rowid || ';') > 0
+                           ORDER BY rl.at DESC LIMIT 1
+                        ) = 'human_confirmed'
+                        THEN strftime('%s','now') * 1000
+                        ELSE NULL
+                      END
+ WHERE x_user_id IS NULL
+   AND source = 'migration:dedup_to_uid_twin';
+
+-- ----- Phase 3 — undo A0b (human_confirmed promotion of uid'd twin)
+UPDATE accounts
+   SET status = (
+         SELECT substr(rl.note,
+                       instr(rl.note, 'prior_status=') + 13,
+                       instr(rl.note, '; prior_source=') - instr(rl.note, 'prior_status=') - 13)
+           FROM review_log rl
+          WHERE rl.action = 'status_promoted'
+            AND rl.actor = 'migration:2026-05-26'
+            AND instr(rl.note, 'inherited human_confirmed status from handle-only sibling; rowid=' || accounts.rowid || ';') > 0
+          ORDER BY rl.at DESC LIMIT 1
+       ),
+       published_at = NULL
+ WHERE x_user_id IS NOT NULL
+   AND status = 'human_confirmed'
+   AND EXISTS (SELECT 1 FROM review_log rl
+                WHERE rl.action = 'status_promoted'
+                  AND rl.actor = 'migration:2026-05-26'
+                  AND instr(rl.note, 'inherited human_confirmed status from handle-only sibling; rowid=' || accounts.rowid || ';') > 0);
+
+-- ----- Phase 4 — undo A0a (whitelisted promotion of uid'd twin) — LOSSY
+UPDATE accounts
+   SET status = (
+         SELECT substr(rl.note,
+                       instr(rl.note, 'prior_status=') + 13,
+                       instr(rl.note, '; prior_source=') - instr(rl.note, 'prior_status=') - 13)
+           FROM review_log rl
+          WHERE rl.action = 'status_promoted'
+            AND rl.actor = 'migration:2026-05-26'
+            AND instr(rl.note, 'inherited whitelisted status from handle-only sibling; rowid=' || accounts.rowid || ';') > 0
+          ORDER BY rl.at DESC LIMIT 1
+       ),
+       source = (
+         SELECT substr(rl.note, instr(rl.note, 'prior_source=') + 13)
+           FROM review_log rl
+          WHERE rl.action = 'status_promoted'
+            AND rl.actor = 'migration:2026-05-26'
+            AND instr(rl.note, 'inherited whitelisted status from handle-only sibling; rowid=' || accounts.rowid || ';') > 0
+          ORDER BY rl.at DESC LIMIT 1
+       ),
+       published_at = NULL
+ WHERE x_user_id IS NOT NULL
+   AND status = 'whitelisted'
+   AND source = 'admin_whitelist'
+   AND EXISTS (SELECT 1 FROM review_log rl
+                WHERE rl.action = 'status_promoted'
+                  AND rl.actor = 'migration:2026-05-26'
+                  AND instr(rl.note, 'inherited whitelisted status from handle-only sibling; rowid=' || accounts.rowid || ';') > 0);

--- a/services/edge/migrations/2026-05-26-identity-cleanup.sql
+++ b/services/edge/migrations/2026-05-26-identity-cleanup.sql
@@ -1,0 +1,243 @@
+-- ============================================================================
+-- 2026-05-26 — identity cleanup (Wave A)
+-- ============================================================================
+-- Collapses three classes of duplicate / orphan rows that accumulated while
+-- the extension was unable to extract X's numeric user id (the fiber walk
+-- fails on some feed/reply contexts, so the same target ended up scored
+-- multiple times — once handle-only, then later with a uid).
+--
+-- Surveyed counts on 2026-05-26 (run preview queries below to verify before
+-- applying):
+--   Class A — handle-only rows where a uid-bearing twin already exists ......  80
+--     of which status=human_confirmed (visible dup on /list) ...............  61
+--     of which status=auto_pending_review (phantom queue items) ............  10
+--     of which status=auto_legit ...........................................   5
+--     other (rejected/removed/whitelisted) .................................   4
+--   Class B — pure-orphan handles with multiple null-uid rows .............. ~34
+--   Class C — `reports` rows with NULL uid that have a uid-bearing twin ....   9
+--
+-- Status promotion: before collapsing duplicates, the strongest maintainer
+-- signal in each handle cluster propagates to the canonical row. Priority:
+--   whitelisted > human_confirmed > rejected > auto_legit > auto_pending_review
+-- This salvages the lone prod case where a maintainer whitelisted a handle-
+-- only row but the uid-bearing twin was still in `auto_legit` (luoleiorg).
+--
+-- Class A/B work is non-destructive: rows are set to status='removed' with a
+-- `source='migration:...'` marker; full payload (verdict, reasons,
+-- evidence_text, signals_hash, last_scored) stays for audit. review_log gets
+-- a row per collapse including the original accounts.rowid, so the rollback
+-- can pair each accounts row back to its specific prior-status entry.
+--
+-- Class C deletes the duplicate `reports` rows outright — they violate the
+-- spirit of the UNIQUE INDEX on (handle, x_user_id, reporter_fp) but slipped
+-- in because SQLite treats multiple NULLs as distinct. The uid-bearing twin
+-- preserves the audit trail.
+--
+-- Roll-back: see migrations/2026-05-26-identity-cleanup.rollback.sql.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- PREVIEW (run before applying; nothing here mutates state)
+-- ----------------------------------------------------------------------------
+-- SELECT a.x_user_id, a.handle, a.status, a.last_scored
+--   FROM accounts a
+--  WHERE a.x_user_id IS NULL
+--    AND EXISTS (SELECT 1 FROM accounts b
+--                 WHERE b.x_user_id IS NOT NULL
+--                   AND lower(b.handle)=lower(a.handle));
+--
+-- WITH null_clusters AS (
+--   SELECT lower(handle) AS h FROM accounts
+--    WHERE x_user_id IS NULL
+--    GROUP BY lower(handle) HAVING count(*) > 1
+-- )
+-- SELECT a.handle, a.status, a.last_scored
+--   FROM accounts a
+--  WHERE a.x_user_id IS NULL
+--    AND lower(a.handle) IN (SELECT h FROM null_clusters)
+--    AND NOT EXISTS (SELECT 1 FROM accounts b
+--                     WHERE b.x_user_id IS NOT NULL
+--                       AND lower(b.handle)=lower(a.handle))
+--  ORDER BY lower(a.handle), a.last_scored DESC;
+--
+-- SELECT id, handle, reporter_fp, created_at FROM reports r
+--  WHERE x_user_id IS NULL
+--    AND EXISTS (SELECT 1 FROM reports s
+--                 WHERE s.x_user_id IS NOT NULL
+--                   AND lower(s.handle)=lower(r.handle)
+--                   AND s.reporter_fp=r.reporter_fp);
+
+-- ----------------------------------------------------------------------------
+-- APPLY (atomic — D1 runs every statement in this file as one batch)
+-- ----------------------------------------------------------------------------
+
+-- ----- A0. Promote: uid-bearing twin inherits the strongest status that any
+--      null-uid sibling holds, so the maintainer's manual whitelisted /
+--      human_confirmed decision survives the collapse. Only PROMOTE — never
+--      demote, never touch already-strongest-status rows.
+
+-- A0a. Promote uid'd twin → 'whitelisted' if any null-uid sibling is whitelisted
+INSERT INTO review_log (x_user_id, handle, action, actor, note, at)
+SELECT a.x_user_id, a.handle, 'status_promoted', 'migration:2026-05-26',
+       'inherited whitelisted status from handle-only sibling; rowid=' || a.rowid
+         || '; prior_status=' || a.status || '; prior_source=' || a.source,
+       strftime('%s','now') * 1000
+  FROM accounts a
+ WHERE a.x_user_id IS NOT NULL
+   AND a.status NOT IN ('whitelisted')
+   AND EXISTS (SELECT 1 FROM accounts s
+                WHERE s.x_user_id IS NULL
+                  AND s.status = 'whitelisted'
+                  AND lower(s.handle) = lower(a.handle));
+
+UPDATE accounts
+   SET status = 'whitelisted',
+       source = 'admin_whitelist',
+       verdict_label = 'legit',
+       confidence = 1.0,
+       reasons = '["whitelisted by admin"]',
+       signals_hash = NULL,
+       published_at = NULL
+ WHERE x_user_id IS NOT NULL
+   AND status <> 'whitelisted'
+   AND EXISTS (SELECT 1 FROM accounts s
+                WHERE s.x_user_id IS NULL
+                  AND s.status = 'whitelisted'
+                  AND lower(s.handle) = lower(accounts.handle));
+
+-- A0b. Promote uid'd twin → 'human_confirmed' if any null-uid sibling is
+--      human_confirmed AND uid'd twin is in a weaker auto_* state. (Don't
+--      downgrade rejected/whitelisted; don't re-promote already-confirmed.)
+--      source is unchanged here, but we still record prior_source so the
+--      rollback can use a single unified parser.
+INSERT INTO review_log (x_user_id, handle, action, actor, note, at)
+SELECT a.x_user_id, a.handle, 'status_promoted', 'migration:2026-05-26',
+       'inherited human_confirmed status from handle-only sibling; rowid=' || a.rowid
+         || '; prior_status=' || a.status || '; prior_source=' || a.source,
+       strftime('%s','now') * 1000
+  FROM accounts a
+ WHERE a.x_user_id IS NOT NULL
+   AND a.status IN ('auto_pending_review','auto_legit')
+   AND EXISTS (SELECT 1 FROM accounts s
+                WHERE s.x_user_id IS NULL
+                  AND s.status = 'human_confirmed'
+                  AND lower(s.handle) = lower(a.handle));
+
+UPDATE accounts
+   SET status = 'human_confirmed',
+       published_at = strftime('%s','now') * 1000
+ WHERE x_user_id IS NOT NULL
+   AND status IN ('auto_pending_review','auto_legit')
+   AND EXISTS (SELECT 1 FROM accounts s
+                WHERE s.x_user_id IS NULL
+                  AND s.status = 'human_confirmed'
+                  AND lower(s.handle) = lower(accounts.handle));
+
+-- ----- A1. Class A — handle-only rows whose canonical uid-bearing twin
+--       already exists. Audit log first (capturing rowid + prior status),
+--       then mark removed. last_scored / verdict / reasons stay untouched.
+INSERT INTO review_log (x_user_id, handle, action, actor, note, at)
+SELECT NULL,
+       a.handle,
+       'dedup_merged',
+       'migration:2026-05-26',
+       'collapsed handle-only row; rowid=' || a.rowid || '; canonical uid=' || (
+         SELECT b.x_user_id FROM accounts b
+          WHERE b.x_user_id IS NOT NULL
+            AND lower(b.handle) = lower(a.handle)
+          LIMIT 1
+       ) || '; prior_status=' || a.status || '; prior_source=' || a.source,
+       strftime('%s','now') * 1000
+  FROM accounts a
+ WHERE a.x_user_id IS NULL
+   AND a.status <> 'removed'
+   AND EXISTS (SELECT 1 FROM accounts b
+                WHERE b.x_user_id IS NOT NULL
+                  AND lower(b.handle) = lower(a.handle));
+
+UPDATE accounts
+   SET status = 'removed',
+       source = 'migration:dedup_to_uid_twin',
+       published_at = NULL
+ WHERE x_user_id IS NULL
+   AND status <> 'removed'
+   AND EXISTS (SELECT 1 FROM accounts b
+                WHERE b.x_user_id IS NOT NULL
+                  AND lower(b.handle) = lower(accounts.handle));
+
+-- ----- B. Class B — pure-orphan clusters: rank by (status_priority DESC,
+--       last_scored DESC) and keep rn=1, mark the rest removed.
+INSERT INTO review_log (x_user_id, handle, action, actor, note, at)
+SELECT NULL,
+       a.handle,
+       'dedup_merged',
+       'migration:2026-05-26',
+       'pure-orphan cluster; rowid=' || a.rowid || '; prior_status=' || a.status || '; prior_source=' || a.source,
+       strftime('%s','now') * 1000
+  FROM accounts a
+ WHERE a.x_user_id IS NULL
+   AND a.status <> 'removed'
+   AND a.rowid IN (
+     WITH ranked AS (
+       SELECT rowid,
+              row_number() OVER (
+                PARTITION BY lower(handle)
+                ORDER BY CASE status
+                           WHEN 'whitelisted'           THEN 0
+                           WHEN 'human_confirmed'       THEN 1
+                           WHEN 'rejected'              THEN 2
+                           WHEN 'auto_legit'            THEN 3
+                           WHEN 'auto_pending_review'   THEN 4
+                           ELSE 5
+                         END,
+                         last_scored DESC,
+                         rowid DESC
+              ) AS rn
+         FROM accounts
+        WHERE x_user_id IS NULL
+          AND status <> 'removed'
+          AND NOT EXISTS (SELECT 1 FROM accounts b
+                           WHERE b.x_user_id IS NOT NULL
+                             AND lower(b.handle) = lower(accounts.handle))
+     )
+     SELECT rowid FROM ranked WHERE rn > 1
+   );
+
+UPDATE accounts
+   SET status = 'removed',
+       source = 'migration:null_dedup_keep_latest',
+       published_at = NULL
+ WHERE rowid IN (
+   WITH ranked AS (
+     SELECT rowid,
+            row_number() OVER (
+              PARTITION BY lower(handle)
+              ORDER BY CASE status
+                         WHEN 'whitelisted'           THEN 0
+                         WHEN 'human_confirmed'       THEN 1
+                         WHEN 'rejected'              THEN 2
+                         WHEN 'auto_legit'            THEN 3
+                         WHEN 'auto_pending_review'   THEN 4
+                         ELSE 5
+                       END,
+                       last_scored DESC,
+                       rowid DESC
+            ) AS rn
+       FROM accounts
+      WHERE x_user_id IS NULL
+        AND status <> 'removed'
+        AND NOT EXISTS (SELECT 1 FROM accounts b
+                         WHERE b.x_user_id IS NOT NULL
+                           AND lower(b.handle) = lower(accounts.handle))
+   )
+   SELECT rowid FROM ranked WHERE rn > 1
+ );
+
+-- ----- C. Class C — `reports` with NULL uid that have a uid-bearing twin
+--       from the same reporter. Keep the uid-bearing one, delete the orphan.
+DELETE FROM reports
+ WHERE x_user_id IS NULL
+   AND EXISTS (SELECT 1 FROM reports s
+                WHERE s.x_user_id IS NOT NULL
+                  AND lower(s.handle) = lower(reports.handle)
+                  AND s.reporter_fp = reports.reporter_fp);


### PR DESCRIPTION
## 背景

扩展 fiber-walk 在 feed/reply 上下文里间歇拿不到 X numeric uid，导致同一个目标在 D1 里被记录多次（先 handle-only，后又 uid'd）。今天上线 CWS 时盘点了一下 prod 数据，已经积累了 ~125 行需要清的污染：

| 类别 | 行数 | 影响 |
|---|---:|---|
| Class A —— 有 uid 双胞胎的 handle-only 行 | **80** | 其中 61 条挂 `human_confirmed` 正在污染 `/list` 公榜 |
| Class B —— 纯孤儿 handle 多行 | **~34** | 队列里幽灵审核任务 + 计数失真 |
| Class C —— 同 reporter 对同 handle 重复 reports（NULL/non-NULL uid 漏洞） | **9** | reporter distinct-count 被虚抬，影响 auto-publish 门槛 |
| 隐藏案例 —— null-uid sibling 已被 whitelisted 但 uid'd 仍在 auto_legit | **1**（`luoleiorg`） | maintainer 的"信任"intent 没传到 canonical 行 |

## 本次改动

仅文件，**不在这条 PR 里 apply**。Apply 由人工触发 `wrangler d1 execute ... --file=...`。

### 新增 3 个文件

- `services/edge/migrations/2026-05-26-identity-cleanup.sql` —— 5 phase 原子 batch：
  - **A0a** 把任意 uid'd 行 promote 成 whitelisted（如果它的 null-uid 兄弟是 whitelisted）
  - **A0b** 把任意 uid'd 行 promote 成 human_confirmed（如果它的 null-uid 兄弟是 human_confirmed）
  - **A1** 把所有"有 uid 双胞胎"的 null-uid 行设为 `status='removed'` + `source='migration:dedup_to_uid_twin'`
  - **B** 同 handle 多 null-uid 行按 (status_priority DESC, last_scored DESC) 排序，保留 rn=1，其它设 removed
  - **C** DELETE 那 9 条重复 reports
- `services/edge/migrations/2026-05-26-identity-cleanup.rollback.sql` —— 4 phase mirror-reverse，按 `rowid` token 精确配对，能把 status + source 还原；A0a 的 verdict/confidence/reasons 是 lossy（文档已注明），C 不可逆
- `docs/MIGRATIONS.md` —— 新建 migration ledger + apply 流程约定

### 审计 trail

每动一行写 1 条 review_log，note 末尾按统一格式：
```
...; prior_status=<status>; prior_source=<source>
```
+ Class A/B 的 note 含 `rowid=<n>;`，rollback 用 `instr()` 精确反向匹配。

## 测试验证

dry-run 在 local D1 里完整跑过：

| 测试 | 结果 |
|---|---|
| 19 行混合种子 → migrate | 13 条 review_log（2 promotion + 7 A + 4 B）+ 9 行 → `removed` + 1 reports DELETE，全部符合预期 |
| 同 SQL 再跑一次 | 0 副作用，幂等 |
| migrate → rollback → vs 种子 | `cmp` 字节级相等 |
| `pnpm typecheck` / `lint` / `test` | 全绿 |

## 风险与回滚

- **对线上扩展的影响**：0 —— 只动 D1 数据，不动 API shape / endpoint。扩展 5 个调用的 endpoint 都不触及被改的状态判断逻辑
- **D1 export 作为兜底安全网**：apply 前会先 `wrangler d1 export xss-db --remote --output ...sql` 留全表快照
- **Rollback**：`wrangler d1 execute xss-db --remote --file=./migrations/2026-05-26-identity-cleanup.rollback.sql`，但 clean rollback window 只有"几分钟"，因为正常扫描会持续 mutate `last_scored`
- **Apply 顺序**：merge → manual apply（不在 CI / 自动化里）

## Apply 顺序（PR merged 之后）

```bash
cd services/edge
npx wrangler d1 export xss-db --remote --output /tmp/xss-db-pre-2026-05-26.sql
npx wrangler d1 execute xss-db --remote --command "<verification SELECT>"
npx wrangler d1 execute xss-db --remote --file=./migrations/2026-05-26-identity-cleanup.sql
npx wrangler d1 execute xss-db --remote --command "<post-apply verification>"
```

## 关联 Issue

无独立 issue —— 由今天 CWS 上线时的数据盘点触发。后续：
- Wave B（写路径补强：Worker `findAccount` 加 by-uid fallback + `Signals.userId` regex + cleanupHandleOnly 扩展到所有 status）—— 另开 PR
- Wave C（schema 加 `UNIQUE INDEX accounts(x_user_id) WHERE NOT NULL`）—— 与 Wave B 同 PR