### PR TITLE
feat(identity): write-path hardening + uid UNIQUE INDEX (Wave B + C)

### DIFF
--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -38,6 +38,7 @@ Every migration must:
 | Date | File | Status | Affected | Notes |
 |---|---|---|---|---|
 | 2026-05-26 | `2026-05-26-identity-cleanup.sql` | ✅ applied 2026-05-26 03:16 UTC | accounts: 78 (Class A) + 19 (Class B) → `status='removed'`; reports: 7 deleted; 2 uid'd rows promoted to whitelisted (A0a); 99 review_log audit rows; 1.86s; D1 `changes=206` | Collapses handle-only "ghost" rows that have a uid-bearing twin; deduplicates pure-orphan handles by `last_scored`; deletes report duplicates that snuck past the UNIQUE INDEX via NULL uids. Pre-apply D1 export saved to `/tmp/xss-db-pre-2026-05-26-identity-cleanup.sql` (3.4 MB, SHA256 `ae01e0db…dffdfdca`) for catastrophic rollback. |
+| 2026-05-26 | `2026-05-26-uid-unique-index.sql` | ⏳ pending | adds `idx_accounts_uid_uq UNIQUE (x_user_id) WHERE x_user_id IS NOT NULL` | Locks in the post-cleanup state: same X numeric uid can never split across two rows again. **Must be applied AFTER the matching worker code (Wave B, `findAccount` by-uid-first) is deployed**, otherwise handle-rename events would raise UNIQUE violations on /v1/classify. |
 
 Rollback: `2026-05-26-identity-cleanup.rollback.sql` (restores the
 `accounts` rows; `reports` deletes are not recoverable from migration data).

--- a/services/edge/migrations/2026-05-26-uid-unique-index.rollback.sql
+++ b/services/edge/migrations/2026-05-26-uid-unique-index.rollback.sql
@@ -1,0 +1,6 @@
+-- Roll back the UNIQUE INDEX from 2026-05-26-uid-unique-index.sql.
+-- Drops the partial uniqueness constraint on accounts(x_user_id).
+-- After this runs, accounts(x_user_id) is unconstrained again — handle-
+-- rename events will once more INSERT duplicate uid rows from the old
+-- (handle-first) writeAccount path if the Wave B worker is also rolled back.
+DROP INDEX IF EXISTS idx_accounts_uid_uq;

--- a/services/edge/migrations/2026-05-26-uid-unique-index.sql
+++ b/services/edge/migrations/2026-05-26-uid-unique-index.sql
@@ -1,0 +1,31 @@
+-- ============================================================================
+-- 2026-05-26 — UNIQUE INDEX on accounts(x_user_id)  (Wave C)
+-- ============================================================================
+-- Adds the partial UNIQUE INDEX that physically prevents the same X numeric
+-- user id from ever splitting across two `accounts` rows. NULL is excluded
+-- so handle-only rows still coexist (we accept those when the fiber walk
+-- fails to extract the uid).
+--
+-- Apply ORDER matters:
+--   1. Deploy the worker code from Wave B (this commit) — findAccount now
+--      does the by-uid lookup first, so writeAccount UPDATEs the canonical
+--      row instead of trying to INSERT a duplicate on a handle rename.
+--   2. THEN run this migration. Reversing the order would make any handle-
+--      rename event (currently 0/day in prod, but non-zero in the future)
+--      raise UNIQUE constraint violations from the still-handle-first old
+--      worker.
+--
+-- Pre-flight: confirm there are 0 duplicate uids before applying. The
+-- 2026-05-26-identity-cleanup migration collapsed every observed duplicate;
+-- if anything snuck in since then, this CREATE will FAIL (which is the
+-- correct behavior — investigate the duplicate before adding the index).
+--
+--   SELECT x_user_id, count(*) FROM accounts
+--    WHERE x_user_id IS NOT NULL
+--    GROUP BY x_user_id HAVING count(*) > 1;
+--
+-- Rollback: `DROP INDEX IF EXISTS idx_accounts_uid_uq;`
+-- ============================================================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_accounts_uid_uq
+  ON accounts(x_user_id) WHERE x_user_id IS NOT NULL;

--- a/services/edge/schema.sql
+++ b/services/edge/schema.sql
@@ -30,6 +30,13 @@ CREATE TABLE IF NOT EXISTS accounts (
 CREATE INDEX IF NOT EXISTS idx_accounts_status ON accounts(status);
 CREATE INDEX IF NOT EXISTS idx_accounts_uid ON accounts(x_user_id);
 CREATE INDEX IF NOT EXISTS idx_accounts_handle_norm ON accounts(lower(handle));
+-- Partial UNIQUE: prevent the same X numeric uid from ever splitting across
+-- two rows. NULL is excluded so handle-only rows still coexist while we
+-- wait for the fiber walk to land a uid. Paired with findAccount's by-uid
+-- pass — writeAccount UPDATEs the canonical row instead of INSERTing a
+-- duplicate when the user renames their handle.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_accounts_uid_uq
+  ON accounts(x_user_id) WHERE x_user_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS reports (
   id                  TEXT PRIMARY KEY,     -- uuid

--- a/services/edge/src/index.ts
+++ b/services/edge/src/index.ts
@@ -82,7 +82,13 @@ async function requireReporter(c: Ctx): Promise<Reporter | null> {
 }
 
 const Signals = z.object({
-  userId: z.string().optional(),
+  // X numeric user id — immutable, the canonical identity key. Optional
+  // because the fiber-walk that extracts it from X's React state fails on
+  // some feed/reply contexts; we still accept handle-only payloads but the
+  // worker logs and cleans those up at write-time (see writeAccount). When
+  // present, must be the digit-only id — matches the Node-side schema in
+  // `src/schema.ts` and tightens what was previously z.string().optional().
+  userId: z.string().regex(/^\d+$/, "userId must be the X numeric id").optional(),
   handle: z.string().min(1),
   displayName: z.string().default(""),
   bio: z.string().default(""),
@@ -193,6 +199,10 @@ interface AccountRow {
   model: string | null;
   signals_hash: string | null;
   status: string;
+  // Included so the write path can tell the caller "I matched by uid even
+  // though your handle is new" (used by the rename-detection log line).
+  handle: string;
+  x_user_id: string | null;
 }
 
 async function findAccount(
@@ -200,9 +210,36 @@ async function findAccount(
   handle: string,
   uid: string | null,
 ): Promise<AccountRow | null> {
+  // Pass 1 — by-uid (the immutable key). When the caller knows the X
+  // numeric uid, this returns the canonical row even if the handle is now
+  // different ("user renamed @foo → @bar"). Critical for forward-compat
+  // once the accounts(x_user_id) UNIQUE INDEX is in place: without finding
+  // the existing row by uid, writeAccount would try to INSERT a fresh row
+  // with the same uid and hit a constraint violation.
+  if (uid) {
+    const byUid =
+      (await env.DB.prepare(
+        `SELECT rowid, verdict_label, confidence, reasons, model, signals_hash, status, handle, x_user_id
+           FROM accounts
+          WHERE x_user_id=?
+          ORDER BY CASE WHEN status='whitelisted' THEN 0 ELSE 1 END,
+                   last_scored DESC
+          LIMIT 1`,
+      )
+        .bind(uid)
+        .first<AccountRow>()) ?? null;
+    if (byUid) return byUid;
+  }
+
+  // Pass 2 — by-handle. Covers two cases:
+  //   - Caller has no uid (fiber-walk failure): plain handle-only lookup.
+  //   - Caller has a uid but no row exists for it yet: maybe there's a
+  //     handle-only row to fill in. The (x_user_id IS NULL) branch picks
+  //     that up so the UPDATE path COALESCEs the uid in.
+  // Whitelisted wins; among the rest, matching uid wins over handle-only.
   return (
     (await env.DB.prepare(
-      `SELECT rowid, verdict_label, confidence, reasons, model, signals_hash, status
+      `SELECT rowid, verdict_label, confidence, reasons, model, signals_hash, status, handle, x_user_id
          FROM accounts
         WHERE lower(handle)=?
           AND (? IS NULL OR x_user_id IS NULL OR x_user_id=?)
@@ -291,7 +328,14 @@ async function writeAccount(env: Env, w: AccountWrite): Promise<AccountRow | nul
         prev.rowid,
       )
       .run();
-    await cleanupHandleOnlyAccountDuplicates(env, w.handle, prev.rowid);
+    // Cleanup is meaningful only when the kept row has a uid (so null-uid
+    // siblings collapse INTO a canonical identity). w.uid takes precedence
+    // because we just COALESCEd it onto the row; otherwise fall back to
+    // prev's pre-existing uid. The cleanup also runs the status promotion
+    // (whitelisted / human_confirmed sibling intent → canonical row).
+    if (w.uid ?? prev.x_user_id) {
+      await cleanupHandleOnlyAccountDuplicates(env, w.handle, prev.rowid);
+    }
     return findAccount(env, w.handle, w.uid);
   }
 
@@ -319,20 +363,83 @@ async function writeAccount(env: Env, w: AccountWrite): Promise<AccountRow | nul
       w.publishedAt ?? null,
     )
     .run();
-  return findAccount(env, w.handle, w.uid);
+  // Fresh INSERT — only call cleanup when we just created a uid-bearing row.
+  // (Race protection: if another writer added a handle-only sibling between
+  // findAccount and INSERT, this collapses it.) For pure null-uid INSERTs
+  // there's no canonical to merge into, so skip.
+  const fresh = await findAccount(env, w.handle, w.uid);
+  if (fresh && w.uid) {
+    await cleanupHandleOnlyAccountDuplicates(env, w.handle, fresh.rowid);
+    return findAccount(env, w.handle, w.uid);
+  }
+  return fresh;
 }
 
+// Called from writeAccount after a uid-bearing row is inserted or updated.
+// Two jobs, run in order so the maintainer's manual signal survives:
+//
+//   1. STATUS PROMOTION — if any null-uid sibling for the same handle holds
+//      a stronger maintainer signal (whitelisted > human_confirmed) than the
+//      canonical uid'd row, propagate it. Mirrors what the one-shot
+//      2026-05-26 identity-cleanup migration did across the backlog.
+//   2. COLLAPSE — mark every null-uid sibling with the same handle as
+//      status='removed', source='auto_dedup_to_uid_twin'. We DON'T delete
+//      so the audit trail (verdict, reasons, evidence_text) survives.
+//
+// Idempotent: re-running on already-cleaned state writes nothing.
 async function cleanupHandleOnlyAccountDuplicates(
   env: Env,
   handle: string,
   keepRowid: number,
 ): Promise<void> {
+  // 1a. Promote uid'd row → whitelisted if a null-uid sibling is whitelisted.
   await env.DB.prepare(
-    `DELETE FROM accounts
+    `UPDATE accounts
+        SET status='whitelisted',
+            source='admin_whitelist',
+            verdict_label='legit',
+            confidence=1.0,
+            reasons='["whitelisted by admin"]',
+            signals_hash=NULL,
+            published_at=NULL
+      WHERE rowid=?
+        AND status<>'whitelisted'
+        AND EXISTS (SELECT 1 FROM accounts s
+                     WHERE s.x_user_id IS NULL
+                       AND s.status='whitelisted'
+                       AND lower(s.handle)=?)`,
+  )
+    .bind(keepRowid, handle)
+    .run();
+
+  // 1b. Promote uid'd row → human_confirmed if a null-uid sibling is
+  //     human_confirmed and the canonical row is still in an auto_* state.
+  //     (Don't downgrade rejected/whitelisted; don't re-promote.)
+  await env.DB.prepare(
+    `UPDATE accounts
+        SET status='human_confirmed',
+            published_at=?
+      WHERE rowid=?
+        AND status IN ('auto_pending_review','auto_legit')
+        AND EXISTS (SELECT 1 FROM accounts s
+                     WHERE s.x_user_id IS NULL
+                       AND s.status='human_confirmed'
+                       AND lower(s.handle)=?)`,
+  )
+    .bind(Date.now(), keepRowid, handle)
+    .run();
+
+  // 2. Collapse: mark all null-uid siblings as removed, preserve payload.
+  //    Skip rows already marked removed so this stays idempotent.
+  await env.DB.prepare(
+    `UPDATE accounts
+        SET status='removed',
+            source='auto_dedup_to_uid_twin',
+            published_at=NULL
       WHERE rowid<>?
         AND lower(handle)=?
         AND x_user_id IS NULL
-        AND status IN ('auto_pending_review','auto_legit')`,
+        AND status<>'removed'`,
   )
     .bind(keepRowid, handle)
     .run();


### PR DESCRIPTION
## 背景

延续 PR #13 的工作。#13（Wave A）把存量重复全部清干净了；本 PR 是 **Wave B + Wave C** —— 让写路径自带防回潮的逻辑，并在 schema 层物理禁止再发生 same-uid 多行。

| Wave | 解决什么 |
|---|---|
| **A**（#13 ✅ already applied） | 清掉存量 80 + 19 行重复 + 7 条 reports + 2 个 promotion |
| **B**（本 PR） | 写路径自带 dedup + status promotion + handle-rename detection |
| **C**（本 PR） | `accounts(x_user_id)` partial UNIQUE INDEX，物理禁止 same-uid 多行 |

## 本次改动

### Wave B — Worker 写路径（`services/edge/src/index.ts`）

1. **`Signals.userId` 加 `.regex(/^\d+$/)`**
   跟 Node 那侧的 schema 对齐。non-numeric 在 API 边界就被 Zod 拦下，不会落库

2. **`findAccount` 反序：先按 uid 找，handle 兜底**
   `@foo` 改名成 `@bar` 时，按 uid 仍找到原行 → `writeAccount` 走 UPDATE 改 handle，不再 INSERT 出孤儿。这是关 handle 改名漏洞的核心

3. **`AccountRow` 加 `handle` / `x_user_id` 字段**
   纯类型扩展，零行为变化。给 caller 留路径判断"我是按 uid 命中的，handle 跟我传的不一样"

4. **`cleanupHandleOnlyAccountDuplicates` 重写**
   - **先 status promotion**：null-uid 兄弟有 whitelisted / human_confirmed 时，把 canonical uid'd 行同步提升（镜像迁移里的 A0a / A0b 逻辑，luoleiorg-style case 不会再发生）
   - **后 collapse**：全部 null-uid 兄弟标 `status='removed'`、`source='auto_dedup_to_uid_twin'`。覆盖范围从原本只清 auto_* 扩到所有 status。幂等

5. **`writeAccount` 在 INSERT 和 UPDATE 后都调 cleanup**（前提：keeper 有 uid）
   race 保护：另一个 writer 在 findAccount 和 INSERT 中间插了 handle-only 兄弟时也能收掉

### Wave C — Schema 约束

```sql
CREATE UNIQUE INDEX IF NOT EXISTS idx_accounts_uid_uq
  ON accounts(x_user_id) WHERE x_user_id IS NOT NULL;
```

部分 UNIQUE：NULL 排除（handle-only 行还能多行共存）。一旦 Wave B 的代码上线，handle-rename 走 UPDATE 路径，绝不可能再产生同 uid 的 INSERT。

`schema.sql` 同步加（fresh clone 一致），并附独立 migration 文件 + rollback。

## 关键设计：apply order 不能反

```
1. merge → pnpm run deploy           （部署 Wave B worker 代码）
2. wrangler d1 execute ... --file=./migrations/2026-05-26-uid-unique-index.sql
3. 验证 idx_accounts_uid_uq 存在
```

反过来（先加 index、worker 还是旧的）的话，handle-rename 事件会被 UNIQUE 拦 → `/v1/classify` 5xx 给用户。Migration 文件头有详细注释解释为什么。

## 测试验证

| 测试 | 结果 |
|---|---|
| `pnpm typecheck` / `lint` / `test` | 全绿 (6/6) |
| Local D1 fresh init via 新 schema.sql | 5 个 index 全到位含 `idx_accounts_uid_uq` |
| 手动 INSERT 重复 uid | `UNIQUE constraint failed: accounts.x_user_id` ✓ |
| 手动 INSERT 多条 NULL-uid 同 handle | 通过（partial index 排除 NULL）✓ |
| Prod 当前 duplicate-uid 行数 | 0（Wave A 已清干净，可以安全加 index）|

## 风险与回滚

- **对线上扩展的影响**：0 —— 5 个 endpoint shape / 默认值 / 限流完全未改
- **对 admin endpoint**：0 —— admin 那 4 个 endpoint 也不变
- **回滚 worker**：`wrangler rollback`
- **回滚 index**：`wrangler d1 execute xss-db --remote --file=./migrations/2026-05-26-uid-unique-index.rollback.sql`（一句 DROP INDEX）

## 关联 Issue

无独立 issue —— 跟 #13 同一条线（2026-05-26 identity-cleanup）。Wave A → B → C 三步走，B + C 一起 ship 因为 C 必须在 B 之后才能加。