### PR TITLE
fix(admin): hide collapsed advanced-filter panel (empty gray box)

### DIFF
--- a/services/edge/src/pages/admin.ts
+++ b/services/edge/src/pages/admin.ts
@@ -174,6 +174,11 @@ input::placeholder{color:var(--fg-4)}
 .search-bar .search-input::placeholder{color:var(--fg-4)}
 .adv-panel{background:var(--card);border:1px solid var(--border);border-radius:var(--r);
   padding:12px 14px;font-size:12.5px}
+/* When collapsed (no 'open' attribute), hide the entire panel — otherwise
+   its bg + border + padding render as a stray gray box between the search
+   input and the verdict chips. The toggle button '更多筛选' sets 'open' via
+   JS so the panel reappears as a normal block. */
+.adv-panel:not([open]){display:none}
 .adv-panel summary{cursor:pointer}
 .adv-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px 14px}
 .adv-grid label{display:flex;flex-direction:column;gap:4px}


### PR DESCRIPTION
## 问题

PR #15 加的更多筛选折叠面板在收起状态下渲染成一个空灰框（截图见你刚才发的）。

## 原因

`<details class="adv-panel">` 默认收起；它的原生 `<summary>` 被 `display:none` 隐藏（因为 toggle 我用外面单独的更多筛选按钮控制）。但 `<details>` 容器**自己**的 bg + border + 12px padding 在收起时仍然渲染 → 空白灰条。

## 修法

加一行 CSS：

```css
.adv-panel:not([open]){display:none}
```

收起时整个容器 `display:none`，灰框消失；展开时 `open` 属性出现，规则不再命中，正常显示。toggle 行为不变。

## 测试验证

`pnpm typecheck` + `lint` 都过。1 行 CSS 改动，无逻辑变化。

## 关联

后续 PR #15 的小 polish。