### PR TITLE
feat(admin): atomic batch endpoints — decide-batch + whitelist-batch

### DIFF
--- a/services/edge/src/index.ts
+++ b/services/edge/src/index.ts
@@ -803,84 +803,206 @@ app.get("/v1/admin/stats", async (c) => {
     reports: reportsRow?.n ?? 0,
   });
 });
+type DecideAction = "approve" | "reject" | "remove" | "whitelist";
+
+function statusForAction(action: DecideAction): string {
+  return action === "approve"
+    ? "human_confirmed"
+    : action === "remove"
+      ? "removed"
+      : action === "whitelist"
+        ? "whitelisted"
+        : "rejected";
+}
+
+// Build the prepared-statement array for a single decide on one (handle, uid?)
+// pair. Shared between /v1/admin/decide (single) and /v1/admin/decide-batch
+// (D1 batch transaction) so the SQL stays in one place — no risk of the
+// batch path drifting from the single path's behavior.
+//
+// Returns 2 statements when xUserId is given (target row + sibling-handle
+// cleanup), 1 when handle-only. The last statement appended by the caller
+// is always the review_log INSERT.
+function buildDecideStatements(
+  env: Env,
+  handle: string,
+  xUserId: string | undefined,
+  action: DecideAction,
+  now: number,
+): D1PreparedStatement[] {
+  const status = statusForAction(action);
+  const stmts: D1PreparedStatement[] = [];
+  if (xUserId) {
+    if (action === "whitelist") {
+      stmts.push(
+        env.DB.prepare(
+          `UPDATE accounts
+              SET status='whitelisted',
+                  source='admin_whitelist',
+                  verdict_label='legit',
+                  confidence=1.0,
+                  reasons='["whitelisted by admin"]',
+                  signals_hash=NULL,
+                  last_scored=?,
+                  published_at=NULL
+            WHERE lower(handle)=? AND x_user_id=?`,
+        ).bind(now, handle, xUserId),
+      );
+    } else {
+      stmts.push(
+        env.DB.prepare(
+          "UPDATE accounts SET status=?, published_at=? WHERE lower(handle)=? AND x_user_id=?",
+        ).bind(status, action === "approve" ? now : null, handle, xUserId),
+      );
+    }
+    // Sibling cleanup: when a uid-bearing row was just promoted/demoted, also
+    // sweep any handle-only auto_pending_review siblings (they're stale).
+    stmts.push(
+      env.DB.prepare(
+        `UPDATE accounts SET status=?, published_at=NULL
+          WHERE lower(handle)=? AND x_user_id IS NULL AND status='auto_pending_review'`,
+      ).bind(action === "approve" || action === "whitelist" ? "removed" : status, handle),
+    );
+  } else {
+    if (action === "whitelist") {
+      stmts.push(
+        env.DB.prepare(
+          `UPDATE accounts
+              SET status='whitelisted',
+                  source='admin_whitelist',
+                  verdict_label='legit',
+                  confidence=1.0,
+                  reasons='["whitelisted by admin"]',
+                  signals_hash=NULL,
+                  last_scored=?,
+                  published_at=NULL
+            WHERE lower(handle)=? AND x_user_id IS NULL`,
+        ).bind(now, handle),
+      );
+    } else {
+      stmts.push(
+        env.DB.prepare(
+          "UPDATE accounts SET status=?, published_at=? WHERE lower(handle)=? AND x_user_id IS NULL",
+        ).bind(status, action === "approve" ? now : null, handle),
+      );
+    }
+  }
+  return stmts;
+}
+
+function reviewLogStmt(
+  env: Env,
+  xUserId: string | null,
+  handle: string,
+  action: string,
+  note: string,
+  now: number,
+): D1PreparedStatement {
+  return env.DB.prepare(
+    "INSERT INTO review_log (x_user_id,handle,action,actor,note,at) VALUES (?,?,?,?,?,?)",
+  ).bind(xUserId, handle, action, "admin", note, now);
+}
+
 app.post("/v1/admin/decide", async (c) => {
   if (!admin(c)) return c.json({ error: "forbidden" }, 403);
   const body = (await c.req.json()) as {
     handle: string;
     xUserId?: string;
-    action: "approve" | "reject" | "remove" | "whitelist";
+    action: DecideAction;
   };
   const handle = normalizeHandle(body.handle);
   const xUserId = body.xUserId;
   const action = body.action;
-  const status =
-    action === "approve"
-      ? "human_confirmed"
-      : action === "remove"
-        ? "removed"
-        : action === "whitelist"
-          ? "whitelisted"
-          : "rejected";
   const now = Date.now();
-  if (xUserId) {
-    if (action === "whitelist") {
-      await c.env.DB.prepare(
-        `UPDATE accounts
-            SET status='whitelisted',
-                source='admin_whitelist',
-                verdict_label='legit',
-                confidence=1.0,
-                reasons='["whitelisted by admin"]',
-                signals_hash=NULL,
-                last_scored=?,
-                published_at=NULL
-          WHERE lower(handle)=? AND x_user_id=?`,
-      )
-        .bind(now, handle, xUserId)
-        .run();
-    } else {
-      await c.env.DB.prepare(
-        "UPDATE accounts SET status=?, published_at=? WHERE lower(handle)=? AND x_user_id=?",
-      )
-        .bind(status, action === "approve" ? now : null, handle, xUserId)
-        .run();
-    }
-    await c.env.DB.prepare(
-      `UPDATE accounts SET status=?, published_at=NULL
-        WHERE lower(handle)=? AND x_user_id IS NULL AND status='auto_pending_review'`,
+  const stmts = buildDecideStatements(c.env, handle, xUserId, action, now);
+  stmts.push(reviewLogStmt(c.env, xUserId ?? null, handle, action, "panel", now));
+  await c.env.DB.batch(stmts);
+  return c.json({ ok: true, status: statusForAction(action) });
+});
+
+// Batch decide — accepts up to 100 items, single homogeneous action, runs as
+// one D1 transaction. Either all rows commit or none do (D1 batch is atomic).
+// Speeds up "拉黑这 80 条" from ~10s of sequential network round-trips to
+// ~300ms in one shot, and removes the half-applied state risk on network
+// hiccups mid-batch.
+//
+// Body: { action: "approve"|"reject"|"remove"|"whitelist",
+//         items: [{ handle: string, xUserId?: string }, ...] }
+const DecideBatchBody = z.object({
+  action: z.enum(["approve", "reject", "remove", "whitelist"]),
+  items: z
+    .array(
+      z.object({
+        handle: z.string().min(1),
+        xUserId: z.string().regex(/^\d+$/).optional(),
+      }),
     )
-      .bind(action === "approve" || action === "whitelist" ? "removed" : status, handle)
-      .run();
-  } else {
-    if (action === "whitelist") {
-      await c.env.DB.prepare(
-        `UPDATE accounts
-            SET status='whitelisted',
-                source='admin_whitelist',
-                verdict_label='legit',
-                confidence=1.0,
-                reasons='["whitelisted by admin"]',
-                signals_hash=NULL,
-                last_scored=?,
-                published_at=NULL
-          WHERE lower(handle)=? AND x_user_id IS NULL`,
-      )
-        .bind(now, handle)
-        .run();
-    } else {
-      await c.env.DB.prepare(
-        "UPDATE accounts SET status=?, published_at=? WHERE lower(handle)=? AND x_user_id IS NULL",
-      )
-        .bind(status, action === "approve" ? now : null, handle)
-        .run();
-    }
+    .min(1)
+    .max(100),
+});
+
+app.post("/v1/admin/decide-batch", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  let body: z.infer<typeof DecideBatchBody>;
+  try {
+    body = DecideBatchBody.parse(await c.req.json());
+  } catch (err) {
+    return c.json({ error: "bad_request", detail: (err as Error).message }, 400);
   }
-  await c.env.DB.prepare(
-    "INSERT INTO review_log (x_user_id,handle,action,actor,note,at) VALUES (?,?,?,?,?,?)",
-  )
-    .bind(xUserId ?? null, handle, action, "admin", "panel", now)
-    .run();
-  return c.json({ ok: true, status });
+  const now = Date.now();
+  const stmts: D1PreparedStatement[] = [];
+  for (const it of body.items) {
+    const h = normalizeHandle(it.handle);
+    stmts.push(...buildDecideStatements(c.env, h, it.xUserId, body.action, now));
+    stmts.push(reviewLogStmt(c.env, it.xUserId ?? null, h, body.action, "panel_batch", now));
+  }
+  await c.env.DB.batch(stmts);
+  return c.json({
+    ok: true,
+    status: statusForAction(body.action),
+    processed: body.items.length,
+  });
+});
+
+// Batch whitelist-remove — drops a list of accounts from the whitelist back
+// to 'rejected'. Same atomic-batch contract as decide-batch.
+const WhitelistBatchBody = z.object({
+  items: z
+    .array(
+      z.object({
+        handle: z.string().min(1),
+        xUserId: z.string().regex(/^\d+$/).optional(),
+      }),
+    )
+    .min(1)
+    .max(100),
+});
+
+app.delete("/v1/admin/whitelist-batch", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  let body: z.infer<typeof WhitelistBatchBody>;
+  try {
+    body = WhitelistBatchBody.parse(await c.req.json());
+  } catch (err) {
+    return c.json({ error: "bad_request", detail: (err as Error).message }, 400);
+  }
+  const now = Date.now();
+  const stmts: D1PreparedStatement[] = [];
+  for (const it of body.items) {
+    const h = normalizeHandle(it.handle);
+    const uid = it.xUserId ?? null;
+    // Mirror the single DELETE endpoint: drop to 'rejected' (preserve audit),
+    // keep the row, log the removal.
+    stmts.push(
+      c.env.DB.prepare(
+        `UPDATE accounts SET status='rejected', source='admin_whitelist', last_scored=?
+          WHERE lower(handle)=? AND (x_user_id IS ? OR x_user_id=?) AND status='whitelisted'`,
+      ).bind(now, h, uid, uid),
+    );
+    stmts.push(reviewLogStmt(c.env, uid, h, "whitelist_remove", "panel_batch", now));
+  }
+  await c.env.DB.batch(stmts);
+  return c.json({ ok: true, processed: body.items.length });
 });
 
 // Paginated AI/decision audit trail. Keyset pagination on the id PK

--- a/services/edge/src/pages/admin.ts
+++ b/services/edge/src/pages/admin.ts
@@ -921,6 +921,22 @@ const SCRIPT = String.raw`
         refreshStats();
       });
   }
+  // Translate the local sel/wlSel/blSel key strings (which encode as
+  // "uid|handle") into the {handle, xUserId} item shape the batch endpoints
+  // expect. Server caps each batch at 100; we chunk locally so the
+  // maintainer can still "select all 200 spammers" without manual splits.
+  var BATCH_CHUNK=100;
+  function selToItems(keys){
+    return keys.map(function(k){
+      var parts=k.split('|');
+      var uid=parts[0]||'';
+      var h=parts[1]||'';
+      return uid?{handle:h,xUserId:uid}:{handle:h};
+    });
+  }
+  function chunked(arr,n){
+    var out=[];for(var i=0;i<arr.length;i+=n)out.push(arr.slice(i,i+n));return out;
+  }
   function batch(action){
     if(!sel.size)return;
     var label={approve:'拉黑',reject:'驳回',remove:'移除'}[action]||action;
@@ -933,21 +949,43 @@ const SCRIPT = String.raw`
     }).then(function(ok){
       if(!ok)return;
       var ks=Array.from(sel);
-      setStatus('批量'+label+'…');
-      var done=0;
-      function next(){
-        if(done>=ks.length){sel.clear();lastSelIdxQ=-1;renderQueue();refreshStats();setStatus('完成 · '+done+' 条');setTimeout(function(){setStatus('')},2500);return}
-        var k=ks[done++],parts=k.split('|');
-        api('/v1/admin/decide',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({handle:parts[1],xUserId:parts[0]||undefined,action:action})})
-          .then(function(){
-            queue=queue.filter(function(a){return key(a)!==k});
-            if(stats.queue!=null){stats.queue=Math.max(0,stats.queue-1);var c=$('cQ');if(c)c.textContent=fmtN(stats.queue)}
+      var chunks=chunked(ks,BATCH_CHUNK);
+      setStatus('批量'+label+' 0/'+ks.length);
+      var done=0,idx=0;
+      function nextChunk(){
+        if(idx>=chunks.length){
+          sel.clear();lastSelIdxQ=-1;renderQueue();refreshStats();
+          setStatus('完成 · '+done+' 条');setTimeout(function(){setStatus('')},2500);
+          return;
+        }
+        var slice=chunks[idx++];
+        var items=selToItems(slice);
+        api('/v1/admin/decide-batch',{
+          method:'POST',
+          headers:{'content-type':'application/json'},
+          body:JSON.stringify({action:action,items:items})
+        }).then(function(r){return r.json()}).then(function(j){
+          if(j&&j.ok){
+            done+=slice.length;
+            // optimistic local prune so the UI reflects success immediately
+            var sliceSet={};slice.forEach(function(k){sliceSet[k]=true});
+            queue=queue.filter(function(a){return !sliceSet[key(a)]});
+            if(stats.queue!=null){
+              stats.queue=Math.max(0,stats.queue-slice.length);
+              var c=$('cQ');if(c)c.textContent=fmtN(stats.queue);
+            }
             setStatus('批量'+label+' '+done+'/'+ks.length);
-            next();
-          })
-          .catch(function(){next()})
+            nextChunk();
+          } else {
+            setStatus('批量'+label+' 失败：'+(j&&j.error||'unknown'));
+            setTimeout(function(){setStatus('')},3500);
+          }
+        }).catch(function(e){
+          setStatus('批量'+label+' 网络错误');
+          setTimeout(function(){setStatus('')},3500);
+        });
       }
-      next();
+      nextChunk();
     });
   }
   function clearSel(){sel.clear();lastSelIdxQ=-1;renderRows()}
@@ -1104,15 +1142,36 @@ const SCRIPT = String.raw`
     }).then(function(ok){
       if(!ok)return;
       var ks=Array.from(wlSel);
-      setStatus('批量移出…');
-      var done=0;
-      function next(){
-        if(done>=ks.length){wlSel.clear();lastSelIdxW=-1;loadWhitelist(false);refreshStats();setStatus('完成 · '+done+' 条');setTimeout(function(){setStatus('')},2500);return}
-        var k=ks[done++],parts=k.split('|'),handle=parts[1],xUserId=parts[0]||null;
-        var q='?handle='+encodeURIComponent(handle)+(xUserId?'&xUserId='+encodeURIComponent(xUserId):'');
-        api('/v1/admin/whitelist'+q,{method:'DELETE'}).then(function(){setStatus('批量移出 '+done+'/'+ks.length);next()}).catch(function(){next()})
+      var chunks=chunked(ks,BATCH_CHUNK);
+      setStatus('批量移出 0/'+ks.length);
+      var done=0,idx=0;
+      function nextChunk(){
+        if(idx>=chunks.length){
+          wlSel.clear();lastSelIdxW=-1;loadWhitelist(false);refreshStats();
+          setStatus('完成 · '+done+' 条');setTimeout(function(){setStatus('')},2500);
+          return;
+        }
+        var slice=chunks[idx++];
+        var items=selToItems(slice);
+        api('/v1/admin/whitelist-batch',{
+          method:'DELETE',
+          headers:{'content-type':'application/json'},
+          body:JSON.stringify({items:items})
+        }).then(function(r){return r.json()}).then(function(j){
+          if(j&&j.ok){
+            done+=slice.length;
+            setStatus('批量移出 '+done+'/'+ks.length);
+            nextChunk();
+          } else {
+            setStatus('批量移出失败：'+(j&&j.error||'unknown'));
+            setTimeout(function(){setStatus('')},3500);
+          }
+        }).catch(function(){
+          setStatus('批量移出 网络错误');
+          setTimeout(function(){setStatus('')},3500);
+        });
       }
-      next();
+      nextChunk();
     });
   }
 
@@ -1264,15 +1323,36 @@ const SCRIPT = String.raw`
     }).then(function(ok){
       if(!ok)return;
       var ks=Array.from(blSel);
-      setStatus('批量'+label+'…');
-      var done=0;
-      function next(){
-        if(done>=ks.length){blSel.clear();lastSelIdxB=-1;loadBlacklist(false);refreshStats();setStatus('完成 · '+done+' 条');setTimeout(function(){setStatus('')},2500);return}
-        var k=ks[done++],parts=k.split('|');
-        api('/v1/admin/decide',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({handle:parts[1],xUserId:parts[0]||undefined,action:action})})
-          .then(function(){setStatus('批量'+label+' '+done+'/'+ks.length);next()}).catch(function(){next()})
+      var chunks=chunked(ks,BATCH_CHUNK);
+      setStatus('批量'+label+' 0/'+ks.length);
+      var done=0,idx=0;
+      function nextChunk(){
+        if(idx>=chunks.length){
+          blSel.clear();lastSelIdxB=-1;loadBlacklist(false);refreshStats();
+          setStatus('完成 · '+done+' 条');setTimeout(function(){setStatus('')},2500);
+          return;
+        }
+        var slice=chunks[idx++];
+        var items=selToItems(slice);
+        api('/v1/admin/decide-batch',{
+          method:'POST',
+          headers:{'content-type':'application/json'},
+          body:JSON.stringify({action:action,items:items})
+        }).then(function(r){return r.json()}).then(function(j){
+          if(j&&j.ok){
+            done+=slice.length;
+            setStatus('批量'+label+' '+done+'/'+ks.length);
+            nextChunk();
+          } else {
+            setStatus('批量'+label+' 失败：'+(j&&j.error||'unknown'));
+            setTimeout(function(){setStatus('')},3500);
+          }
+        }).catch(function(){
+          setStatus('批量'+label+' 网络错误');
+          setTimeout(function(){setStatus('')},3500);
+        });
       }
-      next();
+      nextChunk();
     });
   }
   function wlAdd(){


### PR DESCRIPTION
## 背景

承接上一轮"批量是 N 个串行单请求"的诊断。本 PR 加两个真正的批量 endpoint，把"批量拉黑 100 条"从 ~10s 压到 ~300ms，且**单事务原子**——中途断网不会留半截状态。

## 本次改动

### 服务端

抽两个 helper 共享 SQL：

- `buildDecideStatements()` — 一个 (handle, uid?) target 生成 1-2 条 UPDATE prepared statement
- `reviewLogStmt()` — 一条 review_log INSERT

新增 endpoint：

| Endpoint | Body | 限制 |
|---|---|---|
| `POST /v1/admin/decide-batch` | `{action, items:[{handle, xUserId?}]}` | 1-100 items，Zod 校验 xUserId 必须纯数字 |
| `DELETE /v1/admin/whitelist-batch` | `{items:[{handle, xUserId?}]}` | 1-100 items |

两个端点都用 D1 `batch()` 一次性提交——**全成或全失败**。

`/v1/admin/decide` 旧 endpoint 保留不动，外部 caller 不受影响。

### 前端

`batch()` / `wlBatch()` / `blBatch()` 重写：
- 选中条目按 100 一组切 chunk
- 每个 chunk 发 1 个 batch 请求
- 进度提示按 chunk 跳跃显示，optimistic 本地剪枝立即反馈

共享 `selToItems()` + `chunked()` helper，三个 tab 走同一路径。

## 性能对比（实测 RTT ~80–150ms）

| 选条数 | 旧（串行单请求） | 新（按 100 chunk） |
|---:|---:|---:|
| 10 | ~1s | ~150ms |
| 50 | ~5s | ~250ms |
| 100 | ~10s | ~300ms |
| 200 | ~20s | ~600ms（2 chunks） |

附加：单 chunk 原子，断网中途不会留半截状态。

## 测试验证

- `pnpm typecheck` / `lint` / `test` 全绿
- 本地 wrangler dev 起服务跑：
  - POST `/v1/admin/decide-batch` 3 items approve → `{ok:true, processed:3}`，3 行 `human_confirmed`，3 条 review_log（note=`panel_batch` 区分单条）
  - 缺 handle → 400 + Zod 详细错误
- Code review：单 endpoint 和 batch endpoint 走同一个 helper 生成 prepared statements，行为不可能 drift

## 风险与回滚

- **对线上扩展**：0 影响（admin 路由要 token，扩展无）
- **对老 admin caller**：0 影响，旧 `/v1/admin/decide` 保留
- **D1 batch 限制**：单次 ≤100 items；前端自动切片
- **回滚**：`wrangler rollback`

## 关联

承接今天关于 "单请求 vs 批量" 那次对话。Wave A/B/C identity cleanup + 簇过滤 + batch endpoint，audit panel 这块的核心功能基本齐了。
