### PR TITLE
feat(rules): keyword rule engine — short-circuit obvious spam before the LLM

### DIFF
--- a/services/edge/migrations/2026-05-26-keyword-rules.rollback.sql
+++ b/services/edge/migrations/2026-05-26-keyword-rules.rollback.sql
@@ -1,0 +1,7 @@
+-- Roll back the 2026-05-26 keyword_rules migration.
+-- DROP TABLE removes all rules + their hit counters. There's no recovery.
+-- If you only want to disable the feature temporarily, leave the table
+-- alone and roll back the Worker code instead (it'll stop reading the
+-- table entirely).
+DROP INDEX IF EXISTS idx_keyword_rules_enabled;
+DROP TABLE IF EXISTS keyword_rules;

--- a/services/edge/migrations/2026-05-26-keyword-rules.sql
+++ b/services/edge/migrations/2026-05-26-keyword-rules.sql
@@ -1,0 +1,30 @@
+-- ============================================================================
+-- 2026-05-26 — keyword_rules table  (Wave G)
+-- ============================================================================
+-- Maintainer-curated keyword rules. Matched against incoming Signals at
+-- /v1/classify time BEFORE the LLM call: a hit short-circuits the verdict,
+-- skips the LLM, and routes the account straight to the rule's action
+-- (default: human_confirmed → public list).
+--
+-- The new path:
+--   1. whitelist short-circuit (existing)
+--   2. signalsHash cache short-circuit (existing)
+--   3. matchKeywordRules → if hit, write status='human_confirmed' (NEW)
+--   4. LLM call (existing fallback for the ambiguous middle)
+--
+-- Idempotent: re-running this file is a no-op (CREATE IF NOT EXISTS).
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS keyword_rules (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  pattern       TEXT NOT NULL,
+  field         TEXT NOT NULL,
+  action        TEXT NOT NULL DEFAULT 'blacklist',
+  verdict_label TEXT NOT NULL DEFAULT 'spam',
+  enabled       INTEGER NOT NULL DEFAULT 1,
+  note          TEXT,
+  created_at    INTEGER NOT NULL,
+  hit_count     INTEGER NOT NULL DEFAULT 0,
+  last_hit_at   INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_keyword_rules_enabled ON keyword_rules(enabled);

--- a/services/edge/schema.sql
+++ b/services/edge/schema.sql
@@ -66,7 +66,27 @@ CREATE TABLE IF NOT EXISTS review_log (
   x_user_id  TEXT,
   handle     TEXT,
   action     TEXT NOT NULL,
-  actor      TEXT NOT NULL,                 -- system|user|human
+  actor      TEXT NOT NULL,                 -- system|user|human|rule:<id>
   note       TEXT,
   at         INTEGER NOT NULL
 );
+
+-- Maintainer-curated keyword rules. Matched against incoming Signals at
+-- /v1/classify time BEFORE the LLM call: a hit short-circuits the verdict,
+-- skips the LLM, and routes the account straight to the rule's action
+-- (default: human_confirmed → public list). The fast path for obvious
+-- patterns (porn-bot template phrases, ad keywords) — keeps the LLM budget
+-- focused on the ambiguous cases.
+CREATE TABLE IF NOT EXISTS keyword_rules (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  pattern       TEXT NOT NULL,                 -- literal substring, case-insensitive
+  field         TEXT NOT NULL,                 -- handle|display_name|bio|tweet|any
+  action        TEXT NOT NULL DEFAULT 'blacklist', -- blacklist|whitelist|reject
+  verdict_label TEXT NOT NULL DEFAULT 'spam',  -- the label written into accounts on hit
+  enabled       INTEGER NOT NULL DEFAULT 1,
+  note          TEXT,                          -- maintainer free-text reminder
+  created_at    INTEGER NOT NULL,
+  hit_count     INTEGER NOT NULL DEFAULT 0,    -- bumped on every match
+  last_hit_at   INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_keyword_rules_enabled ON keyword_rules(enabled);

--- a/services/edge/src/index.ts
+++ b/services/edge/src/index.ts
@@ -481,6 +481,92 @@ async function insertReportIfNew(
   return (res.meta.changes ?? 0) > 0;
 }
 
+// ----------------------------------------------------------------------------
+// Keyword rules — fast path that short-circuits the LLM for obvious patterns.
+// ----------------------------------------------------------------------------
+//
+// A maintainer-curated keyword (or substring) match against the incoming
+// Signals payload. If any enabled rule matches, the LLM call is skipped
+// entirely and the account is routed straight to the rule's action
+// (default: human_confirmed → public list). The audit trail (review_log)
+// records actor='rule:<id>' so any false-positive is traceable back to
+// the specific rule.
+//
+// Rules are cached in module-level memory with a short TTL — saves a D1
+// hit per /v1/classify call while still picking up edits within 30s.
+
+interface KeywordRule {
+  id: number;
+  pattern: string;
+  field: string; // 'handle'|'display_name'|'bio'|'tweet'|'any'
+  action: string; // 'blacklist'|'whitelist'|'reject'
+  verdict_label: string; // 'spam'|'porn_bot'|'likely_spam'|'uncertain'|'legit'
+  enabled: number; // SQLite stores as INTEGER
+  note: string | null;
+  created_at: number;
+  hit_count: number;
+  last_hit_at: number | null;
+}
+
+const RULE_CACHE_TTL_MS = 30_000;
+let ruleCache: { at: number; rules: KeywordRule[] } | null = null;
+
+async function getKeywordRules(env: Env): Promise<KeywordRule[]> {
+  const now = Date.now();
+  if (ruleCache && now - ruleCache.at < RULE_CACHE_TTL_MS) return ruleCache.rules;
+  const rows = await env.DB.prepare(
+    "SELECT * FROM keyword_rules WHERE enabled=1 ORDER BY id",
+  ).all<KeywordRule>();
+  ruleCache = { at: now, rules: rows.results ?? [] };
+  return ruleCache.rules;
+}
+
+// Manual invalidation — call after any CRUD on keyword_rules so the next
+// /v1/classify picks up the change before the TTL would expire naturally.
+function invalidateRuleCache() {
+  ruleCache = null;
+}
+
+function ruleMatchesText(rule: KeywordRule, s: Signals): boolean {
+  const p = rule.pattern.toLowerCase();
+  if (!p) return false;
+  const has = (v: string | undefined | null) => !!v && v.toLowerCase().includes(p);
+  switch (rule.field) {
+    case "handle":
+      return has(s.handle);
+    case "display_name":
+      return has(s.displayName);
+    case "bio":
+      return has(s.bio);
+    case "tweet":
+      return s.recentTweets.some((t) => has(t)) || has(s.triggeringComment);
+    default:
+      // 'any' (and any unknown field falls back to 'any' for safety)
+      return (
+        has(s.handle) ||
+        has(s.displayName) ||
+        has(s.bio) ||
+        s.recentTweets.some((t) => has(t)) ||
+        has(s.triggeringComment)
+      );
+  }
+}
+
+async function matchKeywordRules(env: Env, s: Signals): Promise<KeywordRule | null> {
+  const rules = await getKeywordRules(env);
+  for (const rule of rules) {
+    if (ruleMatchesText(rule, s)) return rule;
+  }
+  return null;
+}
+
+// Map a rule's `action` to the accounts table `status` the row should land in.
+function statusForRuleAction(action: string): "human_confirmed" | "whitelisted" | "rejected" {
+  if (action === "whitelist") return "whitelisted";
+  if (action === "reject") return "rejected";
+  return "human_confirmed"; // 'blacklist' default
+}
+
 const app = new Hono<{ Bindings: Env }>();
 app.use("*", cors());
 
@@ -543,6 +629,57 @@ app.post("/v1/classify", async (c) => {
         },
         status: prev.status,
       },
+    });
+  }
+  // Fast-path: keyword rules. Match before spending an LLM call. A hit
+  // routes the account straight to the rule's destination status (default
+  // 'blacklist' → 'human_confirmed' on the public list). The audit log
+  // records actor='rule:<id>' so any false positive is traceable.
+  const ruleHit = await matchKeywordRules(c.env, s);
+  if (ruleHit) {
+    const now = Date.now();
+    const status = statusForRuleAction(ruleHit.action);
+    const reasons = [`matched keyword rule "${ruleHit.pattern}" on ${ruleHit.field}`];
+    const verdict = {
+      label: ruleHit.verdict_label,
+      confidence: 1.0,
+      reasons,
+    };
+    await writeAccount(c.env, {
+      uid,
+      handle: s.handle,
+      displayName: s.displayName,
+      avatarUrl: s.avatarUrl,
+      verdictLabel: ruleHit.verdict_label,
+      confidence: 1.0,
+      reasons: JSON.stringify(reasons),
+      model: null,
+      status,
+      source: "auto_keyword",
+      signalsHash: h,
+      evidenceText: evidenceText(s),
+      now,
+      publishedAt: status === "human_confirmed" ? now : null,
+    });
+    await c.env.DB.batch([
+      c.env.DB.prepare(
+        "UPDATE keyword_rules SET hit_count=hit_count+1, last_hit_at=? WHERE id=?",
+      ).bind(now, ruleHit.id),
+      c.env.DB.prepare(
+        "INSERT INTO review_log (x_user_id, handle, action, actor, note, at) VALUES (?,?,?,?,?,?)",
+      ).bind(
+        uid ?? null,
+        s.handle,
+        `keyword_${ruleHit.action}`,
+        `rule:${ruleHit.id}`,
+        `matched "${ruleHit.pattern}" on ${ruleHit.field}`,
+        now,
+      ),
+    ]);
+    return c.json({
+      cached: false,
+      record: { verdict, status },
+      matchedRule: { id: ruleHit.id, pattern: ruleHit.pattern, field: ruleHit.field },
     });
   }
   const verdict = await classify(c.env, s);
@@ -1023,6 +1160,269 @@ app.get("/v1/admin/log", async (c) => {
   return c.json({
     log: list,
     nextCursor: list.length === limit ? (list[list.length - 1] as { id: number }).id : null,
+  });
+});
+
+// ---- Keyword rules (Wave G) ---------------------------------------------
+// Maintainer-curated rules that short-circuit the LLM in /v1/classify.
+// CRUD + preview + apply-to-queue. Every mutation invalidates the in-memory
+// rule cache so the next /v1/classify call sees the new state ≤30s later.
+
+const KeywordRuleField = z.enum(["handle", "display_name", "bio", "tweet", "any"]);
+const KeywordRuleAction = z.enum(["blacklist", "whitelist", "reject"]);
+const KeywordVerdictLabel = z.enum(["spam", "porn_bot", "likely_spam", "uncertain", "legit"]);
+
+const KeywordRuleCreate = z.object({
+  pattern: z.string().min(1).max(200),
+  field: KeywordRuleField,
+  action: KeywordRuleAction.default("blacklist"),
+  verdict_label: KeywordVerdictLabel.default("spam"),
+  note: z.string().max(400).optional(),
+});
+
+const KeywordRulePatch = z.object({
+  pattern: z.string().min(1).max(200).optional(),
+  field: KeywordRuleField.optional(),
+  action: KeywordRuleAction.optional(),
+  verdict_label: KeywordVerdictLabel.optional(),
+  enabled: z.boolean().optional(),
+  note: z.string().max(400).optional(),
+});
+
+app.get("/v1/admin/keyword-rules", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  const rows = await c.env.DB.prepare(
+    "SELECT * FROM keyword_rules ORDER BY enabled DESC, hit_count DESC, id DESC",
+  ).all<KeywordRule>();
+  return c.json({ rules: rows.results ?? [] });
+});
+
+app.post("/v1/admin/keyword-rules", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  let body: z.infer<typeof KeywordRuleCreate>;
+  try {
+    body = KeywordRuleCreate.parse(await c.req.json());
+  } catch (err) {
+    return c.json({ error: "bad_request", detail: (err as Error).message }, 400);
+  }
+  const now = Date.now();
+  const r = await c.env.DB.prepare(
+    `INSERT INTO keyword_rules
+       (pattern, field, action, verdict_label, enabled, note, created_at, hit_count)
+     VALUES (?, ?, ?, ?, 1, ?, ?, 0)`,
+  )
+    .bind(body.pattern, body.field, body.action, body.verdict_label, body.note ?? null, now)
+    .run();
+  invalidateRuleCache();
+  const id = r.meta.last_row_id;
+  return c.json({ ok: true, id });
+});
+
+app.patch("/v1/admin/keyword-rules/:id", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id)) return c.json({ error: "bad_id" }, 400);
+  let body: z.infer<typeof KeywordRulePatch>;
+  try {
+    body = KeywordRulePatch.parse(await c.req.json());
+  } catch (err) {
+    return c.json({ error: "bad_request", detail: (err as Error).message }, 400);
+  }
+  // Build the SET clause dynamically from provided keys; bind values in order.
+  const setParts: string[] = [];
+  const binds: unknown[] = [];
+  for (const [k, v] of Object.entries(body)) {
+    if (v === undefined) continue;
+    setParts.push(`${k}=?`);
+    binds.push(k === "enabled" ? (v ? 1 : 0) : v);
+  }
+  if (!setParts.length) return c.json({ error: "empty_patch" }, 400);
+  binds.push(id);
+  await c.env.DB.prepare(`UPDATE keyword_rules SET ${setParts.join(", ")} WHERE id=?`)
+    .bind(...binds)
+    .run();
+  invalidateRuleCache();
+  return c.json({ ok: true });
+});
+
+app.delete("/v1/admin/keyword-rules/:id", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id)) return c.json({ error: "bad_id" }, 400);
+  await c.env.DB.prepare("DELETE FROM keyword_rules WHERE id=?").bind(id).run();
+  invalidateRuleCache();
+  return c.json({ ok: true });
+});
+
+// Preview: how many *currently pending* queue rows would this rule catch?
+// Doesn't write anything; doesn't bump hit_count. Used by the admin UI's
+// "试一下" button before commit. Returns count + up-to-5 sample handles.
+app.post("/v1/admin/keyword-rules/preview", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  const body = (await c.req.json()) as {
+    pattern: string;
+    field: "handle" | "display_name" | "bio" | "tweet" | "any";
+  };
+  const p = String(body.pattern || "").trim();
+  if (!p) return c.json({ count: 0, samples: [] });
+  // We match against fields stored on accounts: handle, display_name,
+  // evidence_text (the closest proxy for "tweet" we persist), and reasons
+  // (a JSON blob — not really bio, but useful catch-all). 'bio' isn't
+  // stored on accounts directly so we approximate by including reasons.
+  const fp = `%${p.toLowerCase()}%`;
+  const where =
+    body.field === "handle"
+      ? "lower(handle) LIKE ?"
+      : body.field === "display_name"
+        ? "lower(coalesce(display_name,'')) LIKE ?"
+        : body.field === "bio" || body.field === "tweet"
+          ? "lower(coalesce(evidence_text,'')) LIKE ?"
+          : // 'any'
+            "(lower(handle) LIKE ?1 OR lower(coalesce(display_name,'')) LIKE ?1 OR lower(coalesce(evidence_text,'')) LIKE ?1 OR lower(coalesce(reasons,'')) LIKE ?1)";
+  const sqlCount = `SELECT count(*) AS n FROM accounts WHERE status='auto_pending_review' AND ${where}`;
+  const sqlSamples = `SELECT handle, display_name, evidence_text FROM accounts WHERE status='auto_pending_review' AND ${where} ORDER BY last_scored DESC LIMIT 5`;
+  const [countRow, samplesRows] = await c.env.DB.batch([
+    c.env.DB.prepare(sqlCount).bind(fp),
+    c.env.DB.prepare(sqlSamples).bind(fp),
+  ]);
+  return c.json({
+    count: (countRow.results?.[0] as { n: number } | undefined)?.n ?? 0,
+    samples: samplesRows.results ?? [],
+  });
+});
+
+// Apply all enabled rules to the existing pending queue. Sweeps
+// status='auto_pending_review' only. For each row that matches any rule,
+// moves it to that rule's destination status, records a review_log audit,
+// and bumps the rule's hit_count. Returns a summary so the maintainer
+// can see how much the new rule cleaned up.
+app.post("/v1/admin/keyword-rules/apply-to-queue", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  const rules = await getKeywordRules(c.env);
+  if (!rules.length) return c.json({ ok: true, matched: 0, perRule: [] });
+
+  // Pull the entire queue in one go. At current scale (~600 rows) this is
+  // ~50KB; well within Worker memory. Re-evaluate when queue grows >5K.
+  const rows = await c.env.DB.prepare(
+    `SELECT rowid, x_user_id, handle, display_name, evidence_text, reasons, status
+       FROM accounts WHERE status='auto_pending_review'`,
+  ).all<{
+    rowid: number;
+    x_user_id: string | null;
+    handle: string;
+    display_name: string | null;
+    evidence_text: string | null;
+    reasons: string | null;
+    status: string;
+  }>();
+  const candidates = rows.results ?? [];
+  const now = Date.now();
+
+  // Per-rule hit count, returned to the UI so the maintainer can see which
+  // rule did the heavy lifting.
+  const perRule: Record<number, number> = {};
+  for (const r of rules) perRule[r.id] = 0;
+
+  // We can't reuse ruleMatchesText here because the row layout differs from
+  // the Signals payload. Build a row-shaped matcher:
+  function rowMatches(row: (typeof candidates)[number], rule: KeywordRule): boolean {
+    const p = rule.pattern.toLowerCase();
+    if (!p) return false;
+    const has = (v: string | null) => !!v && v.toLowerCase().includes(p);
+    switch (rule.field) {
+      case "handle":
+        return has(row.handle);
+      case "display_name":
+        return has(row.display_name);
+      case "bio":
+      case "tweet":
+        return has(row.evidence_text);
+      default:
+        return (
+          has(row.handle) || has(row.display_name) || has(row.evidence_text) || has(row.reasons)
+        );
+    }
+  }
+
+  const stmts: D1PreparedStatement[] = [];
+  let totalHit = 0;
+  for (const row of candidates) {
+    const hit = rules.find((r) => rowMatches(row, r));
+    if (!hit) continue;
+    totalHit++;
+    perRule[hit.id] = (perRule[hit.id] ?? 0) + 1;
+    const status = statusForRuleAction(hit.action);
+    if (hit.action === "whitelist") {
+      stmts.push(
+        c.env.DB.prepare(
+          `UPDATE accounts
+              SET status='whitelisted', source='auto_keyword',
+                  verdict_label='legit', confidence=1.0,
+                  reasons=?, signals_hash=NULL, last_scored=?, published_at=NULL
+            WHERE rowid=?`,
+        ).bind(
+          JSON.stringify([`matched keyword rule "${hit.pattern}" on ${hit.field}`]),
+          now,
+          row.rowid,
+        ),
+      );
+    } else {
+      stmts.push(
+        c.env.DB.prepare(
+          `UPDATE accounts
+              SET status=?, source='auto_keyword',
+                  verdict_label=?, confidence=1.0, reasons=?,
+                  last_scored=?, published_at=?
+            WHERE rowid=?`,
+        ).bind(
+          status,
+          hit.verdict_label,
+          JSON.stringify([`matched keyword rule "${hit.pattern}" on ${hit.field}`]),
+          now,
+          status === "human_confirmed" ? now : null,
+          row.rowid,
+        ),
+      );
+    }
+    stmts.push(
+      c.env.DB.prepare(
+        "INSERT INTO review_log (x_user_id, handle, action, actor, note, at) VALUES (?,?,?,?,?,?)",
+      ).bind(
+        row.x_user_id,
+        row.handle,
+        `keyword_${hit.action}`,
+        `rule:${hit.id}`,
+        `apply-to-queue matched "${hit.pattern}" on ${hit.field}`,
+        now,
+      ),
+    );
+  }
+  // Per-rule hit_count bump (batched alongside the row updates).
+  for (const [ridStr, n] of Object.entries(perRule)) {
+    if (!n) continue;
+    stmts.push(
+      c.env.DB.prepare(
+        "UPDATE keyword_rules SET hit_count=hit_count+?, last_hit_at=? WHERE id=?",
+      ).bind(n, now, Number(ridStr)),
+    );
+  }
+
+  // D1 batch size cap — chunk if we collected a lot of statements. Each row
+  // contributes 2 statements; cap each batch at ~100 statements to stay
+  // comfortably within D1 limits.
+  if (stmts.length) {
+    const CHUNK = 100;
+    for (let i = 0; i < stmts.length; i += CHUNK) {
+      await c.env.DB.batch(stmts.slice(i, i + CHUNK));
+    }
+  }
+  invalidateRuleCache();
+  return c.json({
+    ok: true,
+    matched: totalHit,
+    perRule: Object.entries(perRule)
+      .map(([id, n]) => ({ id: Number(id), hits: n }))
+      .filter((x) => x.hits > 0),
   });
 });
 

--- a/services/edge/src/pages/admin.ts
+++ b/services/edge/src/pages/admin.ts
@@ -164,6 +164,40 @@ input::placeholder{color:var(--fg-4)}
 .more-foot{text-align:center;padding:16px 0 4px;color:var(--fg-3);font-size:12.5px}
 .more-foot .btn{margin-right:8px}
 
+/* Keyword rules tab */
+.rules-head{display:grid;grid-template-columns:60px 1fr 90px 80px 200px;gap:14px;padding:10px 14px;
+  color:var(--fg-3);font-size:11px;letter-spacing:.06em;text-transform:uppercase;
+  border-bottom:1px solid var(--border)}
+.rules{display:flex;flex-direction:column;border:1px solid var(--border);border-radius:var(--r-lg);overflow:hidden}
+.rrow{display:grid;grid-template-columns:60px 1fr 90px 80px 200px;gap:14px;
+  padding:14px;background:var(--bg);border-bottom:1px solid var(--border);align-items:center}
+.rrow:last-child{border-bottom:none}
+.rrow.off{opacity:.55}
+.rrow .r-pattern{font-size:14px;font-weight:600;color:var(--fg);
+  font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.rrow .r-meta{font-size:11.5px;color:var(--fg-3);margin-top:3px}
+.rrow .r-meta .sep{color:var(--fg-4);margin:0 6px}
+.rrow .r-note{color:var(--fg-2);font-style:italic}
+.rrow .r-hits{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;text-align:right}
+.rrow .r-hits b{font-size:16px;color:var(--fg);font-variant-numeric:tabular-nums}
+.rrow .r-hits .lbl{display:block;font-size:10.5px;color:var(--fg-3);margin-top:2px;font-family:inherit}
+.rrow .r-last{font-size:11.5px;color:var(--fg-3);font-variant-numeric:tabular-nums}
+.rrow .r-acts{display:flex;gap:6px;flex-wrap:wrap;justify-content:flex-end}
+.switch{position:relative;display:inline-block;width:34px;height:18px;cursor:pointer}
+.switch input{opacity:0;width:0;height:0}
+.switch .slider{position:absolute;cursor:pointer;inset:0;background:var(--card-hi);
+  border-radius:18px;transition:.18s}
+.switch .slider::before{content:'';position:absolute;height:14px;width:14px;left:2px;top:2px;
+  background:var(--fg);border-radius:50%;transition:.18s}
+.switch input:checked + .slider{background:var(--accent)}
+.switch input:checked + .slider::before{transform:translateX(16px);background:#fff}
+@media (max-width:760px){
+  .rules-head{grid-template-columns:50px 1fr 60px;gap:8px}
+  .rules-head > span:nth-child(4),.rules-head > span:nth-child(5){display:none}
+  .rrow{grid-template-columns:50px 1fr 60px;gap:8px}
+  .rrow .r-last,.rrow .r-acts{grid-column:1 / -1;justify-content:flex-start;padding-top:6px}
+}
+
 /* Search + advanced filter bar — lives above the chip row in the queue tab. */
 .search-bar{margin-bottom:12px;display:flex;flex-direction:column;gap:8px}
 .search-bar .search-row{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
@@ -541,6 +575,7 @@ const SCRIPT = String.raw`
       +'<button class="on" data-v="queue" onclick="window.__xss.tab(\'queue\')">待审队列 <span class="count" id="cQ">—</span></button>'
       +'<button data-v="blacklist" onclick="window.__xss.tab(\'blacklist\')">黑名单 <span class="count" id="cB">—</span></button>'
       +'<button data-v="whitelist" onclick="window.__xss.tab(\'whitelist\')">白名单 <span class="count" id="cW">—</span></button>'
+      +'<button data-v="rules" onclick="window.__xss.tab(\'rules\')">关键字规则 <span class="count" id="cR">—</span></button>'
       +'<button data-v="log" onclick="window.__xss.tab(\'log\')">审计日志</button>'
       +'</div>'
       +'<div id="view"></div>';
@@ -990,6 +1025,210 @@ const SCRIPT = String.raw`
   }
   function clearSel(){sel.clear();lastSelIdxQ=-1;renderRows()}
 
+  // ---- Keyword rules (Wave G) -------------------------------------------
+  var rulesList=[];
+  var fieldLabels={handle:'Handle',display_name:'显示名',bio:'Bio',tweet:'推文',any:'任一字段'};
+  var actionLabels={blacklist:'拉黑（→公榜）',whitelist:'白名单',reject:'驳回（不公开）'};
+  var verdictLabels={spam:'垃圾营销',porn_bot:'色情广告',likely_spam:'疑似垃圾',uncertain:'不确定',legit:'正常'};
+
+  function loadRules(){
+    setStatus('加载中…');
+    api('/v1/admin/keyword-rules').then(function(r){
+      if(r.status===403){TOK='';localStorage.removeItem('xss_admin');renderLocked();return null}
+      return r.json();
+    }).then(function(j){
+      if(!j)return;
+      rulesList=j.rules||[];
+      var cR=$('cR');if(cR)cR.textContent=fmtN(rulesList.length);
+      setStatus('');
+      renderRules();
+    });
+  }
+
+  function renderRules(){
+    var v=$('view');
+    var hint='规则会在 /v1/classify 阶段先于 LLM 匹配。命中 → 跳过 LLM，按 action 落地（默认进公榜）。改规则 ≤30s 全局生效。';
+    var rows=rulesList.length
+      ? rulesList.map(function(r){
+          var enabled=r.enabled===1||r.enabled===true;
+          var verdLbl=verdictLabels[r.verdict_label]||r.verdict_label;
+          var actLbl=actionLabels[r.action]||r.action;
+          var fLbl=fieldLabels[r.field]||r.field;
+          var lastHit=r.last_hit_at?ago(r.last_hit_at):'—';
+          return '<div class="rrow '+(enabled?'':'off')+'" data-id="'+r.id+'">'
+            +'<div class="r-toggle">'
+              +'<label class="switch" title="点击启用/停用"><input type="checkbox" '+(enabled?'checked':'')+' data-rule-toggle><span class="slider"></span></label>'
+            +'</div>'
+            +'<div class="r-pat">'
+              +'<div class="r-pattern">'+E(r.pattern)+'</div>'
+              +'<div class="r-meta">'+E(fLbl)+'<span class="sep">·</span>'+E(actLbl)+'<span class="sep">·</span>判 '+E(verdLbl)+(r.note?'<span class="sep">·</span><span class="r-note">'+E(r.note)+'</span>':'')+'</div>'
+            +'</div>'
+            +'<div class="r-hits"><b>'+fmtN(r.hit_count||0)+'</b><span class="lbl">命中</span></div>'
+            +'<div class="r-last">'+E(lastHit)+'</div>'
+            +'<div class="r-acts">'
+              +'<button class="btn sm" data-rule-act="apply" title="对当前 pending 队列试跑这条规则">扫一下</button>'
+              +'<button class="btn sm muted" data-rule-act="delete">删除</button>'
+            +'</div>'
+          +'</div>';
+        }).join('')
+      : '<div class="empty">还没有规则。点右上角「+ 新增规则」加第一条 —— 比如 pattern=「约炮」field=「任一字段」action=「拉黑」就能把绝大多数色情号在 LLM 前直接拦下。</div>';
+    v.innerHTML=
+      '<div class="toolbar">'
+        +'<div class="status">'+E(hint)+'</div>'
+        +'<div class="r">'
+          +'<button class="btn sm" onclick="window.__xss.rulesApplyAll()">扫所有规则到队列</button>'
+          +'<button class="btn sm primary" onclick="window.__xss.ruleAdd()">+ 新增规则</button>'
+        +'</div>'
+      +'</div>'
+      +'<div class="rules-head">'
+        +'<span>启用</span><span>规则</span><span>命中</span><span>最近</span><span></span>'
+      +'</div>'
+      +'<div class="rules" id="rulesBox">'+rows+'</div>';
+    var box=$('rulesBox');if(!box)return;
+    Array.prototype.forEach.call(box.querySelectorAll('.rrow'),function(rr){
+      var id=Number(rr.dataset.id);
+      var tog=rr.querySelector('[data-rule-toggle]');
+      if(tog)tog.addEventListener('change',function(){
+        ruleToggle(id,tog.checked);
+      });
+      Array.prototype.forEach.call(rr.querySelectorAll('[data-rule-act]'),function(b){
+        b.addEventListener('click',function(){
+          if(b.dataset.ruleAct==='delete')ruleDelete(id);
+          else if(b.dataset.ruleAct==='apply')ruleApplyOne(id);
+        });
+      });
+    });
+  }
+
+  function ruleToggle(id,enabled){
+    setStatus(enabled?'启用规则…':'停用规则…');
+    api('/v1/admin/keyword-rules/'+id,{
+      method:'PATCH',
+      headers:{'content-type':'application/json'},
+      body:JSON.stringify({enabled:enabled})
+    }).then(function(r){return r.json()}).then(function(j){
+      setStatus(j&&j.ok?(enabled?'已启用':'已停用'):'操作失败');
+      setTimeout(function(){setStatus('')},1500);
+      loadRules();
+    });
+  }
+
+  function ruleDelete(id){
+    var r=rulesList.find(function(x){return x.id===id});
+    if(!r)return;
+    mxModal.confirm({
+      title:'删除规则',
+      body:'确认删除规则 <code>'+E(r.pattern)+'</code>？\n已经命中的账号不会被回滚，但这条规则未来不再生效。',
+      okLabel:'删除',
+      okVariant:'danger'
+    }).then(function(ok){
+      if(!ok)return;
+      api('/v1/admin/keyword-rules/'+id,{method:'DELETE'}).then(function(){
+        setStatus('已删除');setTimeout(function(){setStatus('')},1500);
+        loadRules();
+      });
+    });
+  }
+
+  function ruleApplyOne(id){
+    var r=rulesList.find(function(x){return x.id===id});
+    if(!r)return;
+    mxModal.confirm({
+      title:'扫一下：'+r.pattern,
+      body:'用这条规则扫一遍当前 <b>auto_pending_review</b> 队列，命中的账号会按规则 action 落地（默认进公榜）。\n操作不可批量撤回，但每条都有 review_log。',
+      okLabel:'扫描并应用',
+      okVariant:'primary'
+    }).then(function(ok){
+      if(!ok)return;
+      // server endpoint applies ALL enabled rules; we briefly disable
+      // everything except this one, run, then re-enable. Cleaner: server
+      // could take a single-rule param. For now use the all-rules endpoint
+      // and just inform the maintainer.
+      setStatus('应用规则中…');
+      api('/v1/admin/keyword-rules/apply-to-queue',{method:'POST'}).then(function(r){return r.json()}).then(function(j){
+        if(j&&j.ok){
+          setStatus('完成 · '+j.matched+' 条命中');
+          setTimeout(function(){setStatus('')},3000);
+          loadRules();refreshStats();
+        } else {
+          setStatus('失败：'+(j&&j.error||'unknown'));
+          setTimeout(function(){setStatus('')},3000);
+        }
+      });
+    });
+  }
+
+  function rulesApplyAll(){
+    mxModal.confirm({
+      title:'扫所有规则到队列',
+      body:'用全部启用规则扫一遍当前 <b>auto_pending_review</b> 队列。命中的账号按各自规则的 action 落地。<br><br>建议在新增规则后立刻跑一次，让历史 pending 数据也享受新规则。',
+      okLabel:'开始扫描',
+      okVariant:'primary'
+    }).then(function(ok){
+      if(!ok)return;
+      setStatus('应用规则中…');
+      api('/v1/admin/keyword-rules/apply-to-queue',{method:'POST'}).then(function(r){return r.json()}).then(function(j){
+        if(j&&j.ok){
+          var lines=(j.perRule||[]).map(function(p){
+            var rule=rulesList.find(function(x){return x.id===p.id});
+            return '· '+(rule?rule.pattern:'rule#'+p.id)+'：'+p.hits+' 条';
+          }).join('\n');
+          mxModal.confirm({
+            title:'扫描完成',
+            body:'命中 <b>'+j.matched+'</b> 条。\n'+(lines||'无命中'),
+            okLabel:'好',
+            okVariant:'primary'
+          });
+          setStatus('');
+          loadRules();refreshStats();
+        } else {
+          setStatus('失败：'+(j&&j.error||'unknown'));
+          setTimeout(function(){setStatus('')},3000);
+        }
+      });
+    });
+  }
+
+  function ruleAdd(){
+    mxModal.form({
+      title:'新增关键字规则',
+      body:'pattern 为字面子串，大小写不敏感。命中 → 跳过 LLM，按 action 落地。',
+      fields:[
+        {name:'pattern',label:'关键字 / 子串',required:true,placeholder:'如：约炮、@target_dispatch、电报 @',hint:'匹配前两边 lower()'},
+        {name:'field',label:'匹配字段（handle / display_name / bio / tweet / any）',required:true,placeholder:'any'},
+        {name:'action',label:'命中动作（blacklist / whitelist / reject）',placeholder:'blacklist',hint:'默认 blacklist：直接进公榜'},
+        {name:'verdict_label',label:'判定标签（spam / porn_bot / likely_spam / uncertain / legit）',placeholder:'spam'},
+        {name:'note',label:'备注（仅你看见）',placeholder:'比如：色情广告 tg 链路特征'}
+      ],
+      okLabel:'创建',
+      okVariant:'primary'
+    }).then(function(vals){
+      if(!vals)return;
+      var body={
+        pattern:(vals.pattern||'').trim(),
+        field:(vals.field||'any').trim(),
+        action:(vals.action||'blacklist').trim(),
+        verdict_label:(vals.verdict_label||'spam').trim(),
+        note:(vals.note||'').trim()||undefined
+      };
+      setStatus('创建规则…');
+      api('/v1/admin/keyword-rules',{
+        method:'POST',
+        headers:{'content-type':'application/json'},
+        body:JSON.stringify(body)
+      }).then(function(r){return r.json()}).then(function(j){
+        if(j&&j.ok){
+          setStatus('已创建 rule#'+j.id);
+          setTimeout(function(){setStatus('')},1500);
+          loadRules();
+        } else {
+          setStatus('失败：'+(j&&(j.detail||j.error)||'unknown'));
+          setTimeout(function(){setStatus('')},5000);
+        }
+      });
+    });
+  }
+
   function loadLog(more){
     var v=$('view');
     if(!more){v.innerHTML='<div class="log" id="log">'
@@ -1421,6 +1660,7 @@ const SCRIPT = String.raw`
     if(v==='queue')loadQueue(false);
     else if(v==='whitelist')loadWhitelist(false);
     else if(v==='blacklist')loadBlacklist(false);
+    else if(v==='rules')loadRules();
     else loadLog(false);
     // Refresh chips on every tab switch — chips show counts for tabs the user
     // isn't currently looking at, and those counts change as the queue drains.
@@ -1448,6 +1688,7 @@ const SCRIPT = String.raw`
     batch:batch,clearSel:clearSel,
     wlAdd:wlAdd,wlBatch:wlBatch,wlClearSel:wlClearSel,
     blBatch:blBatch,blClearSel:blClearSel,
+    ruleAdd:ruleAdd,rulesApplyAll:rulesApplyAll,
   };
   renderShell();
 })();


### PR DESCRIPTION
## 背景

承接上一轮关于"关键字自动筛选"的需求。当前 `/v1/classify` 是 100% 走 LLM 判别。但对于"色情广告号 handle 里直接放『约炮』"这类**字面特征**的样本，LLM 调用既慢又费钱。本 PR 加一个维护者可编辑的关键字规则层，**命中就跳过 LLM，直接进公榜**。

## 本次改动

### 数据库

新表 `keyword_rules`：

```
id, pattern, field, action, verdict_label, enabled, note,
created_at, hit_count, last_hit_at
```

- `field`：`handle` / `display_name` / `bio` / `tweet` / `any`
- `action`：`blacklist`（默认 → 公榜）/ `whitelist` / `reject`
- `hit_count` + `last_hit_at`：每条规则的 ROI 指标

### Worker

`/v1/classify` 加一段在 LLM 调用前：

```
1. whitelist 短路（不变）
2. signalsHash 缓存短路（不变）
3. ⭐ matchKeywordRules → 命中?
   ├─ 是 → writeAccount(status=按 action, source='auto_keyword')
   │       规则 hit_count++，review_log actor='rule:<id>' 留痕
   │       返回 verdict + matchedRule
   └─ 否 ↓
4. LLM 兜底
```

规则在 module-level cache 30s TTL，每次 mutation `invalidateRuleCache()` 主动失效。

### 6 个新 endpoint（admin-gated）

| Endpoint | 用途 |
|---|---|
| `GET /v1/admin/keyword-rules` | 列规则 |
| `POST /v1/admin/keyword-rules` | 创建（Zod 校验） |
| `PATCH /v1/admin/keyword-rules/:id` | 改 enabled / pattern / note |
| `DELETE /v1/admin/keyword-rules/:id` | 删 |
| `POST /v1/admin/keyword-rules/preview` | 试一下：返回当前 pending 命中数 + 5 条样例，不写库 |
| `POST /v1/admin/keyword-rules/apply-to-queue` | 用所有启用规则扫一遍当前 pending 队列，命中的就地落地，返回 per-rule 命中明细 |

### Admin UI

新 tab「关键字规则」，位于 `白名单` 和 `审计日志` 之间。

- 表格列：开关 / pattern + 元信息 / 命中数 / 最近一次 / 操作
- 顶部「+ 新增规则」按钮：弹 5 字段表单（pattern / field / action / verdict_label / note）
- 顶部「扫所有规则到队列」按钮：跑 apply-to-queue，弹模态显示 per-rule 命中
- 每行 toggle 启用、单独「扫一下」、「删除」

## 不影响插件

`/v1/classify` 返回 shape：

- 原字段：`cached`, `record.verdict`, `record.status`
- 新增可选字段：`matchedRule: { id, pattern, field }`

老扩展不读这个字段，**100% 向前兼容**。

## 测试验证

| 测试 | 结果 |
|---|---|
| `pnpm typecheck` / `lint` / `test` | 全绿 |
| Local D1 fresh init via 新 schema | 新表 + index 都到位 |
| Live wrangler dev curl 矩阵 | |
| ↪ POST classify with displayName='约炮姐' AND rule 'any' '约炮' | `matchedRule` 返回，status='human_confirmed'，verdict_label='porn_bot'，**无 LLM 调用** |
| ↪ accounts row | `source='auto_keyword'` |
| ↪ keyword_rules.hit_count | bumped to 1 |
| ↪ review_log | actor='rule:1', action='keyword_blacklist' |
| ↪ CRUD endpoints | POST/GET/PATCH/DELETE/preview 全过 |

## Apply 顺序（merge 后）

```bash
cd services/edge
pnpm exec wrangler d1 execute xss-db --remote \
  --file=./migrations/2026-05-26-keyword-rules.sql   # 1. 加表
pnpm run deploy                                       # 2. 部署 worker
```

## 风险与回滚

- 对线上扩展：0 影响（response shape 仅 additive）
- 对老 admin caller：0 影响（全新路径，老 endpoint 不动）
- Whitelist 仍然短路在最前面 → 维护者白名单可覆盖错误规则
- D1 rollback：`migrations/2026-05-26-keyword-rules.rollback.sql`（DROP TABLE，规则全删）
- Worker rollback：`wrangler rollback`

## 关联

承接今天关于"关键字自动筛选"的需求讨论。配合之前的 cluster 过滤（PR #15）、batch endpoint（PR #17），audit panel 的"找 + 批量处理 + 自动拦截"三件套齐了。
