### PR TITLE
v0.3 — identity hardening + auto-block on confirmed spam + UI rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,14 @@ CONTRIBUTING.md       贡献指南
 
 ## 当前进度
 
-**v0.2.0**（已上线）
+**v0.3.0**（最新，2026-05-26）
+- **身份解析硬化**：拦截 X 自家 `/i/api/graphql/*` 拿真 `rest_id`；JSON-LD / follow-button `data-testid` / React fiber 多源交叉校验；`rest_id ≠ id_str` 或 avatar-id 撞 uid 直接丢弃
+- **viewer-scoped 过滤**：自己 / 已关注 / 已 mute / 已拉黑的号一律绕过，扩展端 + 服务端双层短路
+- **公榜命中自动拉黑**（默认关）：开启后扫到已确认的垃圾号自动拉黑，无需点击；同时覆盖本地缓存确认过的号
+- **UI 重写**：浅色主题、每行可勾选的批量拉黑、异步上报状态机；防 prompt-injection 的 `escHtml` 加固
+- 管理面板左上角换成小蓝吉祥物
+
+**v0.2.0**（首发，2026-05-25）
 - 浏览器扩展（Chrome MV3）— 被动 AI 识别 + 一键真拉黑
 - 公开服务端 — `x.zuoluo.tv` / `/list` 公榜 / `/admin` 审核台
 - 维护者白名单 + 黑名单的 6h 自动同步到仓库 [`data/`](./data) 目录

--- a/docs/CWS_LISTING.md
+++ b/docs/CWS_LISTING.md
@@ -6,6 +6,9 @@
 > ✅ **已上架** —— [`chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea`](https://chromewebstore.google.com/detail/make-x-great-again/aeoldnecphbkkckeedfgfcdcekkljdea)。
 > 本文档保留作为后续更新（新版本提交、字段调整、被驳回重提）的参考底稿。
 > 任何字段改动以 Chrome Web Store Developer Dashboard 的实际状态为准。
+>
+> **当前文案版本：v0.3.0**（2026-05-26 提交）。v0.2 的历史文案见
+> git history。每次新版上架前请同步更新本文档对应字段。
 
 ---
 
@@ -14,48 +17,114 @@
 | 字段 | 内容 |
 |---|---|
 | Name (Listing) | MXGA — X spam shield |
-| Summary (单行，132 字符内) | 静默识别 X 上的色情/广告 spam bot，给你一键拉黑。开源、零数据收集。 |
+| Summary (单行，132 字符内) | AI 静默识别 X 上的色情 / 广告 spam bot，给你一键真拉黑（可选自动模式）。完全开源、零数据收集。 |
 | Category | Productivity |
 | Language | 中文 (简体) — primary，可后加英语 |
 
 ## 2. Description（长描述，可粘贴到商店）
 
 ```
-你是不是也觉得 X 越来越没法刷了？
+你是不是也觉得 X 越来越没法刷了?
 
-随便点开一条热门推文，评论区一半是「比她好看的没她骚 @xxx 🍄🌳」这种
-导流模板色情 bot，正常讨论沉到下面五十层。MXGA 帮你被动地把这些号
-识别出来，并一键拉黑（驱动 X 自己的屏蔽 UI，不是 hide，不伪造请求）。
+随便点开一条热门推文,评论区一半是「比她好看的没她骚 @xxx 🍄🌳」这种
+导流模板色情 bot,正常讨论沉到下面五十层。MXGA 帮你被动地把这些号
+识别出来,并一键拉黑(驱动 X 自己的屏蔽 UI,不是 hide,不伪造请求,
+拉黑跨你所有设备同步)。
 
-## 它做什么
+完全开源 (AGPL-3.0):github.com/foru17/make-x-great-again
+官网 / 公榜:https://x.zuoluo.tv
 
-- 你正常刷 X，扩展在后台 **静默** 把每个评论作者过一遍：
-  - 维护者白名单 → 绿勾，跳过
-  - 公开黑名单（人工确认过） → 红色「公榜」标记，立刻可拉黑
-  - 本地缓存 → 灰色「缓存」标记
-  - AI 实时判定（spam / porn_bot / likely_spam / uncertain / legit）
-    → 琥珀「AI」标记
-- 发现可疑时右上角气泡列出本页所有可疑账号，可以
-  - 单独勾选 / 取消勾选
-  - 一键批量拉黑（真拉黑 X 账号，不是隐藏）
-  - 单条手动复核
-  - 进入 X 该账号的主页
+═══════════════════════════════════════
 
-## 它不做什么
+【它怎么工作】
 
-- **不收集** 你的 X 账号 / 邮箱 / 设备指纹 / IP
-- **不爬** X 的隐藏数据，只读 X 已经渲染给你看的公开信息
-- **不会** 自动屏蔽任何账号；扩展只在你按"拉黑"时才动 X 的屏蔽 API
-- **不读** 你 GitHub 上的私有内容（OAuth 范围仅 read:user，只为防滥用计数）
+你正常刷 X,扩展在后台静默把每个评论作者过一遍:
 
-## 治理
+• 维护者白名单 → 绿勾「白名单」,跳过,不动它
+• 公开黑名单(人工确认过) → 红色「公榜」标记
+• 本地缓存 → 灰色「缓存」标记
+• AI 实时判定 → 琥珀「AI」标记
+  (spam / porn_bot / likely_spam / uncertain / legit)
 
-- 公榜入榜不是 AI 单方面说了算 —— 全部经过维护者人工确认
-- 严格只判定商业 spam 和色情广告 bot，**不碰** 观点、立场、政治、身份
-- 误判？开 GitHub issue 申诉：https://github.com/foru17/make-x-great-again/issues
+发现可疑账号时,右上角气泡会列出本页所有可疑号:
 
-完全开源 (AGPL-3.0)，源码：https://github.com/foru17/make-x-great-again
-官网：https://x.zuoluo.tv
+• 每行可勾选 / 取消勾选 —— 挑着拉,不强制全拉
+• 一键批量拉黑(限速队列,不会被 X 反垃圾误伤)
+• 单条手动复核,跳转到该账号 X 主页
+• 上报按钮带状态:上报中 → 已上报 / 失败
+
+═══════════════════════════════════════
+
+【v0.3 新增】
+
+✅ 对已确认的垃圾号自动拉黑(默认关)
+  开启后,扫到公榜确认 / 本机此前判过 spam 的号会被
+  静默后台拉黑,不再需要逐个点。开关在「设置 → 检测行为」。
+
+✅ 自己人不打架
+  你自己、你关注的人、你 mute 或 block 的人,
+  扩展完全跳过 —— 不会被自己 / 朋友的号污染公榜信任分。
+
+✅ 浅色 / 深色主题
+  自动跟随系统主题,深夜刷 X 不刺眼。
+
+✅ 身份解析硬化
+  从 X 自家的接口拿真账号 ID,不再被头像 URL 误导,
+  把误伤同名账号的可能性降到接近零。
+
+✅ 安全加固
+  即便恶意账号在 bio 里写 prompt injection 试图劫持 AI 输出,
+  扩展端会做严格的 HTML 转义,不会被 RCE。
+
+═══════════════════════════════════════
+
+【它不做什么】
+
+✗ 不收集你的 X 账号 / 邮箱 / 设备指纹 / IP
+  唯一上传的标识是公开的 X 数字 ID + 你的 GitHub 数字 ID
+  (后者仅用于防滥用计数,GitHub OAuth 范围严格 read:user)。
+
+✗ 不爬 X 隐藏数据
+  只读 X 已经渲染在页面上给你看的公开内容。
+
+✗ 默认不自动屏蔽任何账号
+  「自动拉黑」开关默认关闭。打开后也只对已经社区 / 维护者
+  确认过的 spam 账号生效,不会自动屏蔽 AI 一手判定的号。
+
+✗ 不读你 GitHub 私有内容
+  OAuth Device Flow 登录,scope 仅 read:user,
+  只为读取你的 GitHub 数字 ID。
+
+═══════════════════════════════════════
+
+【治理 —— 公榜不是 AI 说了算】
+
+入榜双门:
+  • AI 置信度 ≥ 0.9(且标签是 spam / porn_bot)
+  • ≥ 3 个注册超过 90 天的 GitHub 账号独立举报
+
+任一条件不满足,只进人工审核队列,**永远不会自动公开**。
+
+严格只判商业 spam 和色情广告 bot,
+**不碰** 任何观点、立场、政治、身份。
+
+误判申诉:开 GitHub issue,维护者会复核并支持移除。
+
+═══════════════════════════════════════
+
+【关于 LLM】
+
+后端用 OpenAI 兼容的 /chat/completions 接口。
+扩展只传 X 公开页面上已经渲染的字段(handle、显示名、bio、
+本次触发的那条公开推文)。供应商坐标、API key 全部存在
+Cloudflare Worker secret,不入仓库、不进客户端。
+
+═══════════════════════════════════════
+
+开源 · AGPL-3.0
+源码:https://github.com/foru17/make-x-great-again
+公榜:https://x.zuoluo.tv/list
+申诉:https://github.com/foru17/make-x-great-again/issues
 ```
 
 ## 3. Permissions Justification（提交表单里有一栏一栏的）
@@ -72,9 +141,29 @@
 
 ## 4. Single Purpose 声明
 
-> The single purpose of this extension is to identify and let the user
-> block commercial-spam and pornographic-advertising bot accounts on
-> X (Twitter), passively, on the pages the user is already viewing.
+**v0.3 起更新（明确把 user-enabled 自动模式写进 single purpose,避免审核员
+看到自动拉黑设置时怀疑越界）**：
+
+英文版（提交时主用,审核员主要看这版）：
+
+> Identify commercial-spam and pornographic-advertising bot accounts on
+> X (Twitter), passively on pages the user is already viewing, and let
+> the user block them — either one-by-one or, when the user explicitly
+> enables it, automatically for accounts the community has already
+> confirmed.
+
+中文版（如果商店表单是中文,粘这一版）：
+
+> 在用户已经访问的 X (Twitter) 页面上,被动识别商业垃圾推广账号和色情
+> 广告 bot 账号,并让用户屏蔽它们(手动逐个,或在用户主动开启自动模式后
+> 由扩展自动屏蔽社区已确认的账号)。
+
+**关键设计**：把 auto-block 写进单一用途,并强调两点:
+1. *user explicitly enables* —— 默认关,需要用户主动开
+2. *community already confirmed* —— 只对公榜 / 本地缓存确认过的号生效,不是 AI 单方面
+
+这两点是 Chrome Web Store 审核员对扩展自动化最敏感的红线,先在 Single
+Purpose 里写明白,省得 v0.3 提交后被怀疑越界。
 
 ## 5. Privacy Practices 声明（表单里一栏一栏的）
 
@@ -109,13 +198,22 @@ https://github.com/foru17/make-x-great-again/blob/main/docs/PRIVACY.md
 
 | # | 内容 | 来源 |
 |---|---|---|
-| 1 | X 评论区里气泡显示「本页发现 N 个可疑账号」+ 列表 | content-script 实际运行截图 |
+| 1 | X 评论区里气泡显示「本页发现 N 个可疑账号」+ 列表（含每行 checkbox） | content-script 实际运行截图 |
 | 2 | 单个推文旁的红色公榜命中 badge + popover | content-script |
 | 3 | 一键拉黑 + 进度（已完成 M / 选中 N） | 气泡卡片 |
 | 4 | popup 主面板（成就 hero + 三栏统计 + 登录状态） | popup |
-| 5 | options 设置（GitHub 登录 + 检测行为 + 数据与隐私 + 清除） | options |
+| 5 | options 设置（GitHub 登录 + 检测行为 含 v0.3「自动拉黑」开关 + 数据与隐私 + 清除） | options |
 
 > 还没准备好？参考 https://x.zuoluo.tv/list 公榜的视觉风格做。
+
+> **v0.3 截图需要重出**：UI 改了浅色主题 + 每行 checkbox + 雷达进度环 +
+> 设置页加了「自动拉黑」开关。原 v0.2 截图跟当前 build 视觉对不上,审核员
+> 一比对会减分或要求补材料。新截图建议:
+> - #1 / #3：bubble 气泡新雷达环 + per-row checkbox（这是 v0.3 视觉标志）
+> - #4：管理面板左上角小蓝吉祥物（不再是通用盾牌 SVG）
+> - #5：设置页务必把「对已确认的垃圾号自动拉黑」开关入镜（OFF 状态即可,
+>   重点是让审核员看到默认关闭 + 说明文案,呼应 Single Purpose 里的承诺）
+> - 至少出 1 张浅色主题 + 1 张深色主题,展示双主题支持
 
 ## 7. 已知合规风险点
 
@@ -148,3 +246,21 @@ https://github.com/foru17/make-x-great-again/blob/main/docs/PRIVACY.md
 5. 如果 listing 文案 / 截图 / 权限有变，同步更新本文档第 1–7 节并保存
 6. 提交审核（通常 1–3 天；敏感品类可能 7–14 天）
 7. 通过后同步把 GitHub Release 也打一份，让两边版本号一致
+
+## 10. v0.3.0 更新 checklist（2026-05-26）
+
+- [x] `extension/package.json` 版本号 0.2.0 → 0.3.0
+- [x] `pnpm zip` 产出 `.output/mxga-extension-0.3.0-chrome.zip`(139.63 KB)
+- [x] 本文档第 1 节 Summary、第 2 节 Description、第 4 节 Single Purpose 已按 v0.3 更新
+- [x] `docs/STATUS.md` + `README.md` 同步 v0.3 增量
+- [ ] **真机冒烟** —— 装新 zip 到日常 Chrome,跑一遍：
+  - [ ] 进自己 profile / follow 的 KOL profile → 不出现 badge(viewer-scoped 过滤生效)
+  - [ ] 设置 → 检测行为 → 看到「对已确认的垃圾号自动拉黑」开关,默认 OFF
+  - [ ] 打开开关,刷过 Mary @Mary1463962 / Mark @Mark76056378472 → 被自动拉黑
+  - [ ] 管理面板拉黑记录 → 看到来源标签「公榜命中」/「缓存命中」
+  - [ ] 系统切到浅色模式 → bubble 跟着变浅色
+  - [ ] 悬浮卡 reasons 显示纯文本(没有 HTML 元素被渲染,验证 escHtml 加固)
+- [ ] 出 v0.3 新截图(参考第 6 节注释,至少含双主题)
+- [ ] 上传 zip + 粘新版 Description + 新版 Single Purpose 到 CWS Dashboard
+- [ ] 提交审核,等 1-3 天
+- [ ] 审核通过后:`gh release create v0.3.0 --file mxga-extension-0.3.0-chrome.zip`,GitHub Release 跟 CWS 对齐

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -39,10 +39,22 @@ toolchain** for the classifier.
 
 | 组件 | 作用 | 栈 | 状态 |
 |---|---|---|---|
-| `extension/` | 消费端 MV3 扩展（检测/拉黑/面板/登录） | WXT, React, Shadow DOM | 可用 |
+| `extension/` | 消费端 MV3 扩展（检测/拉黑/面板/登录） | WXT, React, Shadow DOM | 可用（v0.3.0：GraphQL 身份解析 + 公榜命中自动拉黑 + viewer-scoped 过滤 + 浅色主题） |
 | `services/edge/` | 边缘 API + D1 + /admin | Hono, Zod, Wrangler | **已部署**线上 |
 | `src/` | 本地分类器/CLI/旧 localhost 服务 | tsx, Zod, node:test | 早期，部分被 edge 取代 |
 | `docs/` | ARCHITECTURE/UX/FLOW/PRODUCT/MODERATION/MVP/RUNNING/STATUS | — | 较全 |
+
+### 3.1 扩展 v0.3.0 增量（2026-05-26）
+
+| 模块 | 改动 | 说明 |
+|---|---|---|
+| 身份解析 | 多源 + 冲突保护 | MAIN-world fetch/XHR 拦截 X 自家 `/i/api/graphql/*` 响应，跟 JSON-LD `mainEntity.identifier` / follow-button `data-testid` / React fiber `rest_id` 交叉校验；rest_id ≠ id_str 或 avatar-id 撞 uid 直接丢弃。新增 `extension/lib/graphql-users.ts` 共享模块 + `entrypoints/x-graphql-main.content.ts` MAIN-world 脚本。 |
+| Viewer-scoped 过滤 | 你自己 / 已 follow / 已 mute / 已 block 的号一律绕过 | 前端 step 0 短路；服务端 `/v1/classify` + `/v1/report` 也短路返回 `{ ignored: true, status: "viewer_ignored" }`，不写 D1。signals 上新增 5 个 viewer 字段。 |
+| 公榜命中自动拉黑 | 设置开关 `autoBlockListHits`，默认 OFF | 开启后：扫到公榜已确认账号 → 静默进入限速拉黑队列；finalizeBlocked 跳过 `confirm_spam` 上报（账号已确认，再上报无新信号）。`BlockSource = "list_hit"`。 |
+| UI 重写 | 浅色主题 + 每行勾选 + 异步上报状态机 + 雷达环进度 | `prefers-color-scheme` 自动适配；一键拉黑变成"拉黑选中"，支持 per-row uncheck；上报按钮状态机：上报 → 上报中 → 已上报 / 失败。 |
+| XSS 加固 | `escHtml` 统一转义 | LLM `reasons` / `note` / 头像 URL / 显示名 / handle 全部统一转义；防止 prompt-injection 走 X bio → LLM → 悬浮卡 innerHTML → 内容脚本上下文 RCE 路径。 |
+| 管理面板 | 左上角换成小蓝吉祥物 + 新增"自动拉黑"开关 | 之前是通用盾牌 SVG。 |
+| 测试 | 新增 `test/uid-detection.test.ts` | 9 条 `ingestGraphqlUsers` 公开 API 契约回归。 |
 
 ## 4. 依赖
 
@@ -66,7 +78,9 @@ Wrangler 4 · @cloudflare/workers-types · @types/chrome。
   `review_log`、`publications`。状态机：auto_pending_review → human_confirmed
   / rejected / removed。`/v1/check` 只返回 human_confirmed。
 - **chrome.storage.local**：`xss:v1:*` 账号判定缓存、`xss:blocklist:v2`
-  拉黑记录、`xss:stats` 统计、`xss:blockQueue` 拉黑队列、`xss:ghToken/
+  拉黑记录、`xss:stats` 统计、`xss:blockQueue` 拉黑队列（v0.3 起每个
+  item 带 `source: "manual" | "list_hit"`）、`xss:settings`（含 v0.3
+  新加的 `autoBlockListHits` 开关，默认 false）、`xss:ghToken/
   ghLogin/ghClientId`、`xss:edgeBase`。仅本机、无 PII。
 
 ## 6. 部署/运行现状
@@ -91,7 +105,7 @@ Wrangler 4 · @cloudflare/workers-types · @types/chrome。
    [ARCHITECTURE.md](./ARCHITECTURE.md) 设计的低成本/可缓存模型尚未落地。
 3. **分类器逻辑双份**：`src/llm.ts` 与 `services/edge` 各一套 SYSTEM 提示，
    易漂移（已发生过需两处同改）。
-4. **无 CI / 扩展与 edge 无测试**：只有 `src/` 早期 node:test。
+4. **测试覆盖薄**：CI 三作业绿门禁已上（`.github/workflows/ci.yml`：core / extension / edge），但运行时测试只有 `src/` 早期 node:test + v0.3 新加的 `test/uid-detection.test.ts`；扩展 DOM 流程和 edge handler 尚无 e2e/integration。
 5. **X DOM/接口脆弱**：选择器与拉黑流程随 X 改版会坏，需持续维护。
 6. **管理端鉴权较轻**：当前以维护者密钥保护，后续可升级到多人身份和轮换机制。
 

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -10,6 +10,7 @@ import {
   extractProfile,
   extractThreadTopic,
   heuristic,
+  ingestGraphqlUsers,
 } from "../lib/detect";
 import type { BgResponse, CurationRecord, Signals, Verdict } from "../lib/types";
 import {
@@ -164,6 +165,11 @@ function mountBadge(anchor: HTMLElement, build: () => HTMLElement) {
   const host = document.createElement("span");
   host.className = "xss-mount";
   host.style.display = "inline-flex";
+  host.style.alignItems = "center";
+  host.style.verticalAlign = "middle";
+  host.style.flex = "0 0 auto";
+  host.style.maxWidth = "none";
+  host.style.lineHeight = "1";
   const sr = host.attachShadow({ mode: "open" });
   const st = document.createElement("style");
   st.textContent = STYLE;
@@ -185,6 +191,11 @@ function mountStatus(anchor: HTMLElement, kind: "analyzing" | "pending") {
   const host = document.createElement("span");
   host.className = cls; // pending = NOT final, scan() will revisit
   host.style.display = "inline-flex";
+  host.style.alignItems = "center";
+  host.style.verticalAlign = "middle";
+  host.style.flex = "0 0 auto";
+  host.style.maxWidth = "none";
+  host.style.lineHeight = "1";
   const sr = host.attachShadow({ mode: "open" });
   const st = document.createElement("style");
   st.textContent = STYLE;
@@ -199,6 +210,7 @@ export default defineContentScript({
   async main(ctx) {
     let bubbleApi: ReturnType<typeof createBubble> | null = null;
     let dismissed = false;
+    let canReport = false;
     const inflight = new Map<string, Promise<void>>(); // L0 in-flight de-dup
     const anchorByKey = new Map<string, HTMLElement>();
     const nodeKey = new WeakMap<HTMLElement, string>(); // virtualization-safe
@@ -224,8 +236,28 @@ export default defineContentScript({
     // L0a — pull the maintainer whitelist mirror into memory so the gate
     // check in classify() is synchronous. Cheap (one chrome.storage read).
     await loadWhitelistOnce();
+    void send<{ login?: string }>({ type: "gh_status" }).then((r) => {
+      const nextCanReport = !!r.ok && !!r.data?.login;
+      if (nextCanReport !== canReport) {
+        canReport = nextCanReport;
+        document
+          .querySelectorAll<HTMLElement>('[data-testid="User-Name"]')
+          .forEach(clearMounts);
+        setTimeout(scan, 0);
+      }
+    });
     const isReplyContext = () => /^\/[^/]+\/status\/\d+/.test(location.pathname);
     const keyOf = (s: Signals) => s.userId || `h:${s.handle}`;
+
+    window.addEventListener("mxga:x-users", (ev) => {
+      if (!(ev instanceof CustomEvent) || typeof ev.detail !== "string") return;
+      try {
+        const payload = JSON.parse(ev.detail) as { users?: Parameters<typeof ingestGraphqlUsers>[0] };
+        if (payload.users && ingestGraphqlUsers(payload.users)) setTimeout(scan, 0);
+      } catch {
+        /* ignore malformed page events */
+      }
+    });
 
     function pushFinding(sig: Signals, v: Verdict) {
       if (!["spam", "porn_bot", "likely_spam"].includes(v.label)) return;
@@ -271,14 +303,18 @@ export default defineContentScript({
       return apiBlock(sig.userId, sig.handle);
     }
 
-    async function finalizeBlocked(key: string, sig: Signals) {
+    async function finalizeBlocked(
+      key: string,
+      sig: Signals,
+      source: "manual" | "list_hit" | "cache_hit" = "manual",
+    ) {
       await addBlocked(key);
       if (sig.userId) await addBlocked(sig.userId);
       const f = findings.find((x) => (x.userId || x.handle) === (sig.userId || sig.handle));
       await addBlockRecord({
         id: key,
         handle: sig.handle,
-        source: "manual",
+        source,
         ts: Date.now(),
         ...(sig.displayName ? { displayName: sig.displayName } : {}),
         ...(sig.avatarUrl ? { avatarUrl: sig.avatarUrl } : {}),
@@ -286,7 +322,19 @@ export default defineContentScript({
       });
       await bumpStats({ blocks: 1 });
       hideTweet(anchorByKey.get(key) ?? null);
-      void send({ type: "confirm_spam", signals: sig }); // human-confirm signal
+      // Skip the confirm_spam re-report on auto-block paths:
+      //  - "list_hit"  : account is already publicly confirmed (that's how
+      //    we got here); another confirm adds no evidence.
+      //  - "cache_hit" : the user did not just take an explicit per-account
+      //    action — they enabled a blanket setting. We treat the block as a
+      //    private hygiene action, not a human-confirm signal to the public
+      //    DB (otherwise toggling auto-block would inflate reporter counts
+      //    based on stale local cache).
+      // Manual blocks DO send confirm_spam — that's the user's explicit
+      // per-account "yes, this is spam" signal.
+      if (source === "manual") {
+        void send({ type: "confirm_spam", signals: sig });
+      }
       const i = findings.findIndex((x) => (x.userId || x.handle) === (sig.userId || sig.handle));
       if (i >= 0) findings.splice(i, 1);
       if (!dismissed) bubbleApi?.update(findings);
@@ -304,12 +352,18 @@ export default defineContentScript({
     }
 
     // ---- Durable, non-blocking, rate-limit-aware bulk block queue ----
-    type QItem = { key: string; sig: Signals; tries: number };
+    // "manual"    → user clicked block / bulk-block button
+    // "list_hit"  → autoBlockListHits + public-blacklist match (step 2)
+    // "cache_hit" → autoBlockListHits + local cache says spam (step 1)
+    type QSource = "manual" | "list_hit" | "cache_hit";
+    type QItem = { key: string; sig: Signals; tries: number; source: QSource };
     let queue: QItem[] = [];
     let draining = false;
     const QK = "xss:blockQueue";
     const persistQ = () =>
-      chrome.storage.local.set({ [QK]: queue.map((q) => ({ key: q.key, sig: q.sig, tries: q.tries })) });
+      chrome.storage.local.set({
+        [QK]: queue.map((q) => ({ key: q.key, sig: q.sig, tries: q.tries, source: q.source })),
+      });
 
     async function drain() {
       if (draining) return;
@@ -320,7 +374,7 @@ export default defineContentScript({
         bubbleApi?.setScanning(queue.length); // progress: 拉黑中 N
         const ok = await tryRealBlock(it.sig).catch(() => false);
         if (ok) {
-          await finalizeBlocked(it.key, it.sig);
+          await finalizeBlocked(it.key, it.sig, it.source);
           // Mark the finding as done so the next card render strikes it out
           // (gives the user feedback that progress is happening — otherwise
           // the "处理中…" button reads as stuck on profile pages where each
@@ -356,19 +410,31 @@ export default defineContentScript({
       if (!dismissed) bubbleApi?.update(findings);
     }
 
-    function enqueueBlocks(items: { key: string; sig: Signals }[]) {
+    function enqueueBlocks(
+      items: { key: string; sig: Signals }[],
+      source: QSource = "manual",
+    ) {
       for (const x of items) {
-        if (!queue.some((q) => q.key === x.key)) queue.push({ ...x, tries: 0 });
+        if (!queue.some((q) => q.key === x.key)) queue.push({ ...x, tries: 0, source });
       }
       void persistQ();
       void drain(); // non-blocking; returns immediately
     }
 
-    // Resume a queue interrupted by reload/navigation.
+    // Resume a queue interrupted by reload/navigation. Older persisted items
+    // may lack `source` (pre-autoBlockListHits builds) — default them to
+    // "manual" so the drain loop keeps the same behavior it had before.
     void chrome.storage.local.get(QK).then((g) => {
-      const saved = g[QK] as QItem[] | undefined;
+      const saved = g[QK] as Partial<QItem>[] | undefined;
       if (saved?.length) {
-        queue = saved;
+        queue = saved
+          .filter((q): q is QItem & { source?: QSource } => !!q.key && !!q.sig)
+          .map((q) => ({
+            key: q.key,
+            sig: q.sig,
+            tries: q.tries ?? 0,
+            source: q.source ?? "manual",
+          }));
         void drain();
       }
     });
@@ -376,10 +442,87 @@ export default defineContentScript({
     // De-dup the "已扫"counter — a single account may render a badge
     // multiple times (recycled DOM node) and we don't want a double-count.
     const scannedKeys = new Set<string>();
+    const ignoredKeys = new Set<string>();
+    // Keys for which we've already enqueued a list_hit auto-block. Without
+    // this, scan() would re-fire the public /v1/check lookup on every tick
+    // (every ~600ms via MutationObserver) until the paced block queue
+    // actually drains and addBlocked() makes step 0b short-circuit. Cheap
+    // local guard, no persistence — restored block queue items can no-op
+    // re-enqueue safely anyway.
+    const autoBlockingKeys = new Set<string>();
     function tallyScan(key: string) {
       if (scannedKeys.has(key)) return;
       scannedKeys.add(key);
       bubbleApi?.bumpScanned();
+    }
+    function isViewerKnownIgnored(sig: Signals) {
+      return (
+        sig.viewerIsSelf ||
+        sig.viewerFollowing ||
+        sig.viewerBlocking ||
+        sig.viewerMuting ||
+        sig.viewerFollowRequestSent
+      );
+    }
+    function dropFinding(sig: Signals) {
+      const id = sig.userId || sig.handle;
+      const i = findings.findIndex((f) => (f.userId || f.handle) === id);
+      if (i >= 0) {
+        findings.splice(i, 1);
+        if (!dismissed) bubbleApi?.update(findings);
+      }
+    }
+    async function reportAccount(sig: Signals) {
+      const resp = await send({ type: "report_spam", signals: sig });
+      if (!resp.ok) throw new Error(resp.error || "上报失败");
+    }
+    /**
+     * Silent auto-block routing — shared by step 1 (cache) and step 2 (list).
+     *
+     * Two source-dependent rules:
+     *   list_hit  → `/v1/check` server-side filters to status='human_confirmed'
+     *               rows only. Being returned IS the confirmation; the verdict
+     *               label is metadata about what the AI originally thought.
+     *               An admin can blacklist an "uncertain 35%" account, and
+     *               when they do, auto-block MUST still fire — otherwise the
+     *               whole feature looks broken on admin-curated entries. So
+     *               for list_hit we IGNORE verdict.label entirely.
+     *   cache_hit → the local cache reflects this device's prior LLM judgment,
+     *               which is NOT a human-confirmed signal. Auto-block only on
+     *               spammy labels (spam / porn_bot / likely_spam) — never on
+     *               an "uncertain" or "legit" cache row the user themselves
+     *               would have been free to ignore.
+     *
+     * Bug history (v0.3):
+     *   - First cut filtered by verdict.label in both branches. That meant
+     *     admin-blacklisted "uncertain"-labeled accounts (a real case in
+     *     prod: see Mary @Mary1463962 / Mark @Mark76056378472) were never
+     *     auto-blocked even though the public list contained them.
+     *   - Earlier cut only checked the list at step 2 — but step 1 cache
+     *     short-circuits first, so anyone with prior LLM cache for the
+     *     account never reached step 2 at all.
+     *
+     * Returns true if this account is now owned by the auto-block queue —
+     * the caller MUST return immediately without rendering badges, pushing
+     * findings, or doing any further work for this key.
+     */
+    function tryAutoBlock(
+      key: string,
+      sig: Signals,
+      verdict: Verdict,
+      anchor: HTMLElement,
+      source: "list_hit" | "cache_hit",
+    ): boolean {
+      if (!settings.autoBlockListHits) return false;
+      if (source === "cache_hit") {
+        const spammy = ["spam", "porn_bot", "likely_spam"].includes(verdict.label);
+        if (!spammy) return false;
+      }
+      autoBlockingKeys.add(key);
+      tallyScan(key); // count it in the bubble's "已扫" total
+      enqueueBlocks([{ key, sig }], source);
+      clearMounts(anchor); // the cell collapses once the queue's finalizeBlocked runs
+      return true;
     }
     function badgeFor(
       anchor: HTMLElement,
@@ -397,9 +540,10 @@ export default defineContentScript({
           {
             onBlock: () => void blockAccount(key, sig),
             onHide: () => hideTweet(anchor),
-            onReport: () => void send({ type: "report_spam", signals: sig }),
+            onReport: () => reportAccount(sig),
             onAppeal: () => window.open(APPEAL_URL, "_blank", "noopener"),
             onCheck: () => void classify(anchor, key, sig),
+            canReport,
           },
           note,
           source,
@@ -449,9 +593,28 @@ export default defineContentScript({
       const key = keyOf(sig);
       anchorByKey.set(key, anchor);
 
-      // 0. Already blocked → hide, never render/analyze/request again.
+      // 0. Viewer-owned / viewer-followed / viewer-muted accounts are out
+      // of scope for MXGA: do not lookup, classify, report, or show badges.
+      if (isViewerKnownIgnored(sig)) {
+        ignoredKeys.add(key);
+        clearMounts(anchor);
+        dropFinding(sig);
+        return;
+      }
+
+      // 0b. Already blocked → hide, never render/analyze/request again.
       if (isBlockedSync(key) || (sig.userId && isBlockedSync(sig.userId))) {
         hideTweet(anchor);
+        return;
+      }
+
+      // 0c. Already enqueued for silent auto-block on an earlier tick — the
+      //     paced drain queue owns it; skip cache / list / LLM work so we
+      //     don't repeat lookups or stack up badges while finalizeBlocked
+      //     is still pending. Once drain succeeds, addBlocked() makes 0b
+      //     short-circuit instead.
+      if (autoBlockingKeys.has(key)) {
+        clearMounts(anchor);
         return;
       }
 
@@ -469,6 +632,12 @@ export default defineContentScript({
       //    unchanged so new evidence can still re-trigger).
       const cached = await cacheGet(key);
       if (cached) {
+        // 1a. autoBlockListHits power-user opt-in: a cached-spammy verdict
+        //     is the system's own prior judgment that this account is spam.
+        //     Without this branch, anyone who had ever LLM-classified spam
+        //     before enabling the toggle would see auto-block do nothing on
+        //     those accounts — they'd short-circuit at renderCached below.
+        if (tryAutoBlock(key, sig, cached.verdict, anchor, "cache_hit")) return;
         const spammy = ["spam", "porn_bot", "likely_spam"].includes(cached.verdict.label);
         if (spammy || cached.signalsHash === signalsHash(sig)) {
           renderCached(anchor, key, sig, cached);
@@ -484,8 +653,13 @@ export default defineContentScript({
           userId: sig.userId,
         });
         if (r.ok && r.data?.hit) {
-          badgeFor(anchor, key, sig, r.data.hit.verdict, undefined, "list");
-          pushFinding(sig, r.data.hit.verdict);
+          const hitVerdict = r.data.hit.verdict;
+          // 2a. autoBlockListHits power-user opt-in: public-blacklist hits
+          //     are community-confirmed spam, so block silently on every
+          //     page the user visits, no card / badge / click required.
+          if (tryAutoBlock(key, sig, hitVerdict, anchor, "list_hit")) return;
+          badgeFor(anchor, key, sig, hitVerdict, undefined, "list");
+          pushFinding(sig, hitVerdict);
           return;
         }
       }
@@ -551,7 +725,10 @@ export default defineContentScript({
         if (topic && !info.threadTopic) info.threadTopic = topic;
         const key = keyOf(info);
         const hasMount = !!nameBlock.querySelector(":scope > .xss-mount");
-        if (nodeKey.get(art) === key && hasMount) continue;
+        if (nodeKey.get(art) === key) {
+          if (ignoredKeys.has(key)) continue;
+          if (hasMount && !isViewerKnownIgnored(info)) continue;
+        }
         if (nodeKey.get(art) !== key) clearMounts(nameBlock); // recycled node
         nodeKey.set(art, key);
         void process(info, nameBlock);

--- a/extension/entrypoints/options/App.tsx
+++ b/extension/entrypoints/options/App.tsx
@@ -350,7 +350,12 @@ function Blocklist() {
       ),
     [list, q],
   );
-  const src: Record<string, string> = { manual: "手动", block_all: "一键全部", list_hit: "名单命中" };
+  const src: Record<string, string> = {
+    manual: "手动",
+    block_all: "一键全部",
+    list_hit: "公榜命中",
+    cache_hit: "缓存命中",
+  };
   return (
     <Page
       title="拉黑记录"
@@ -652,6 +657,12 @@ function Settings() {
               label="回复区逐个自动检查"
               hint="关闭可显著降低 LLM 调用 / 更克制"
             />
+            <Toggle
+              on={st.autoBlockListHits}
+              onChange={(v) => save("autoBlockListHits", v)}
+              label="对已确认的垃圾号自动拉黑"
+              hint="开启后：扫到的色情/垃圾账号会被静默后台拉黑（包括公榜命中 + 本机此前判过 spam 的缓存号），不弹卡片、不需要点确认。默认关闭。"
+            />
           </section>
         )}
 
@@ -769,21 +780,19 @@ const About = () => (
   </Page>
 );
 
-const Shield = () => (
-  <svg
-    width="22"
-    height="22"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.75"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden
-  >
-    <path d="M12 2 4 5v6c0 5 3.4 9.4 8 11 4.6-1.6 8-6 8-11V5l-8-3Z" />
-    <path d="m9 12 2 2 4-4" />
-  </svg>
+// 小蓝 mascot — same PNG as the toolbar icon + the popup header. We use the
+// runtime URL helper instead of bundling a duplicate asset, and render at
+// 28px (retina-safe — the source is 128×128) for a chunkier sidebar mark
+// than the popup's 32px version.
+const MASCOT_URL = chrome.runtime.getURL("icon/128.png");
+const Mascot = () => (
+  <img
+    src={MASCOT_URL}
+    alt={BRAND.name}
+    width={28}
+    height={28}
+    className="flex-none rounded-md"
+  />
 );
 
 const TABS = [
@@ -801,9 +810,7 @@ export function App() {
     <div className="flex min-h-screen">
       <aside className="sticky top-0 flex h-screen w-[220px] flex-none flex-col gap-6 border-r border-border px-4 py-6">
         <div className="flex items-center gap-2.5 px-1 text-[15px] font-semibold tracking-[-0.005em]">
-          <span className="text-fg">
-            <Shield />
-          </span>
+          <Mascot />
           <span className="flex flex-col gap-px leading-tight">
             <span>{BRAND.acronym}</span>
             <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-fg-4">{BRAND.name}</span>

--- a/extension/entrypoints/x-graphql-main.content.ts
+++ b/extension/entrypoints/x-graphql-main.content.ts
@@ -1,0 +1,173 @@
+interface GraphqlUserSnapshot {
+  handle: string;
+  userId: string;
+  bio?: string;
+  displayName?: string;
+  avatarUrl?: string;
+  followersCount?: number;
+  followingCount?: number;
+  createdAt?: string;
+  viewerFollowing?: boolean;
+  viewerBlocking?: boolean;
+  viewerMuting?: boolean;
+  viewerFollowRequestSent?: boolean;
+}
+
+const GRAPHQL_USER_EVENT = "mxga:x-users";
+const GRAPHQL_URL_RE = /\/i\/api\/graphql\/[^/]+\/[^/?#]+/;
+const NUMERIC_ID_RE = /^\d+$/;
+
+function numericId(v: unknown): string | undefined {
+  return typeof v === "string" && NUMERIC_ID_RE.test(v) ? v : undefined;
+}
+
+function text(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function number(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function trueFlag(v: unknown): true | undefined {
+  return v === true ? true : undefined;
+}
+
+function object(v: unknown): Record<string, unknown> | undefined {
+  return v && typeof v === "object" ? (v as Record<string, unknown>) : undefined;
+}
+
+function collectUsers(payload: unknown): GraphqlUserSnapshot[] {
+  const out = new Map<string, GraphqlUserSnapshot>();
+  const seen = new WeakSet<object>();
+  const budget = { n: 12000 };
+
+  function walk(value: unknown, depth: number) {
+    const o = object(value);
+    if (!o || depth > 28 || budget.n-- <= 0) return;
+    if (seen.has(o)) return;
+    seen.add(o);
+
+    if (o.__typename === "User") {
+      const legacy = object(o.legacy) ?? {};
+      const core = object(o.core) ?? {};
+      const avatar = object(o.avatar) ?? {};
+      const relationship = object(o.relationship_perspectives) ?? {};
+      const restId = numericId(o.rest_id);
+      const legacyId = numericId(legacy.id_str);
+      const userId = legacyId ?? restId;
+      const handle = text(legacy.screen_name) ?? text(core.screen_name);
+      if (userId && restId && legacyId && restId !== legacyId) return;
+      if (userId && handle) {
+        out.set(handle.toLowerCase(), {
+          handle,
+          userId,
+          ...(text(legacy.description) !== undefined ? { bio: text(legacy.description) } : {}),
+          ...(text(legacy.name) ?? text(core.name) ? { displayName: text(legacy.name) ?? text(core.name) } : {}),
+          ...(text(legacy.profile_image_url_https) ?? text(avatar.image_url)
+            ? { avatarUrl: text(legacy.profile_image_url_https) ?? text(avatar.image_url) }
+            : {}),
+          ...(number(legacy.followers_count) !== undefined
+            ? { followersCount: number(legacy.followers_count) }
+            : {}),
+          ...(number(legacy.friends_count) !== undefined
+            ? { followingCount: number(legacy.friends_count) }
+            : {}),
+          ...(text(legacy.created_at) ?? text(core.created_at)
+            ? { createdAt: text(legacy.created_at) ?? text(core.created_at) }
+            : {}),
+          ...(trueFlag(legacy.following) ?? trueFlag(relationship.following)
+            ? { viewerFollowing: true }
+            : {}),
+          ...(trueFlag(legacy.blocking) ?? trueFlag(relationship.blocking)
+            ? { viewerBlocking: true }
+            : {}),
+          ...(trueFlag(legacy.muting) ?? trueFlag(relationship.muting)
+            ? { viewerMuting: true }
+            : {}),
+          ...(trueFlag(legacy.follow_request_sent) ?? trueFlag(relationship.follow_request_sent)
+            ? { viewerFollowRequestSent: true }
+            : {}),
+        });
+      }
+    }
+
+    for (const child of Object.values(o)) walk(child, depth + 1);
+  }
+
+  walk(payload, 0);
+  return [...out.values()];
+}
+
+function emitUsers(payload: unknown) {
+  const users = collectUsers(payload);
+  if (!users.length) return;
+  window.dispatchEvent(
+    new CustomEvent(GRAPHQL_USER_EVENT, {
+      detail: JSON.stringify({ users: users.slice(0, 200) }),
+    }),
+  );
+}
+
+function shouldInspectUrl(url: unknown): boolean {
+  return typeof url === "string" && GRAPHQL_URL_RE.test(url);
+}
+
+export default defineContentScript({
+  matches: ["https://x.com/*", "https://twitter.com/*"],
+  runAt: "document_start",
+  world: "MAIN",
+  main() {
+    const originalFetch = window.fetch;
+    window.fetch = async (...args) => {
+      const response = await originalFetch(...args);
+      const url =
+        args[0] instanceof Request
+          ? args[0].url
+          : typeof args[0] === "string"
+            ? args[0]
+            : response.url;
+      if (shouldInspectUrl(url)) {
+        void response
+          .clone()
+          .json()
+          .then(emitUsers)
+          .catch(() => {});
+      }
+      return response;
+    };
+
+    const originalOpen = XMLHttpRequest.prototype.open;
+    const originalSend = XMLHttpRequest.prototype.send;
+    XMLHttpRequest.prototype.open = function open(
+      method: string,
+      url: string | URL,
+      async?: boolean,
+      username?: string | null,
+      password?: string | null,
+    ) {
+      this.__mxgaGraphqlUrl = shouldInspectUrl(url) ? String(url) : undefined;
+      const openFn = originalOpen as unknown as (...args: unknown[]) => void;
+      if (async === undefined) return openFn.call(this, method, url);
+      return openFn.call(this, method, url, async, username, password);
+    };
+    XMLHttpRequest.prototype.send = function send(body?: Document | XMLHttpRequestBodyInit | null) {
+      if (this.__mxgaGraphqlUrl) {
+        this.addEventListener("loadend", () => {
+          try {
+            if (typeof this.responseText === "string") emitUsers(JSON.parse(this.responseText));
+          } catch {
+            /* ignore non-JSON / opaque responses */
+          }
+        });
+      }
+      return originalSend.call(this, body);
+    };
+  },
+});
+
+declare global {
+  interface XMLHttpRequest {
+    __mxgaGraphqlUrl?: string;
+  }
+}

--- a/extension/lib/detect.ts
+++ b/extension/lib/detect.ts
@@ -2,6 +2,9 @@
 // content script. Reads only what X already rendered — no scraping, no
 // navigation, no extra requests to X.
 import type { Signals } from "./types";
+import { type KnownUser, ingestGraphqlUsers, readGraphqlUser } from "./graphql-users";
+
+export { ingestGraphqlUsers } from "./graphql-users";
 
 // Conservative Chinese porn-bot vocabulary. Kept SMALL on purpose — we
 // don't want to play whack-a-mole with bot copy variants. The LLM is what
@@ -31,6 +34,8 @@ const NON_PROFILE = new Set([
   "compose", "hashtag", "bookmarks", "lists", "communities", "jobs", "tos",
   "privacy", "login", "signup",
 ]);
+const TWITTER_SNOWFLAKE_EPOCH_MS = 1_288_834_974_657n;
+const UID_CREATED_AT_TOLERANCE_MS = 2 * 86_400_000;
 
 export function parseJoinDate(text: string | null | undefined): number | undefined {
   if (!text) return undefined;
@@ -68,11 +73,66 @@ function numericId(v: unknown): string | undefined {
   return typeof v === "string" && /^\d+$/.test(v) ? v : undefined;
 }
 
+function numericString(v: unknown): string | undefined {
+  if (typeof v === "number" && Number.isSafeInteger(v)) return String(v);
+  return numericId(v);
+}
+
+function trueFlag(v: unknown): true | undefined {
+  return v === true ? true : undefined;
+}
+
 function bannerUserId(scope: Element | Document): string | undefined {
   const el = scope.querySelector<HTMLElement>('[src*="profile_banners/"], [style*="profile_banners/"]');
   const raw =
     el instanceof HTMLImageElement ? el.src : (el?.getAttribute("style") ?? "");
   return numericId(raw.match(/profile_banners\/(\d+)\//)?.[1]);
+}
+
+function snowflakeTimeMs(id: string): number | undefined {
+  if (id.length < 16) return undefined;
+  try {
+    return Number((BigInt(id) >> 22n) + TWITTER_SNOWFLAKE_EPOCH_MS);
+  } catch {
+    return undefined;
+  }
+}
+
+// X exposes the canonical profile user id as JSON-LD on profile pages. Prefer
+// it there: unlike profile_images/<n>, mainEntity.identifier is the account id.
+function profileJsonLdUserId(expectedHandle?: string): string | undefined {
+  for (const script of document.querySelectorAll<HTMLScriptElement>(
+    'script[type="application/ld+json"]',
+  )) {
+    try {
+      const data = JSON.parse(script.textContent ?? "") as unknown;
+      const pages = Array.isArray(data) ? data : [data];
+      for (const page of pages) {
+        if (!page || typeof page !== "object") continue;
+        const p = page as Record<string, unknown>;
+        if (p["@type"] !== "ProfilePage") continue;
+        const entity = p.mainEntity;
+        if (!entity || typeof entity !== "object") continue;
+        const e = entity as Record<string, unknown>;
+        if (e["@type"] !== "Person") continue;
+
+        const handle =
+          normalizeHandle(typeof e.additionalName === "string" ? e.additionalName : undefined) ??
+          normalizeHandle(
+            typeof e.url === "string"
+              ? e.url.match(/\/([^/?#]+)(?:[?#].*)?$/)?.[1]
+              : undefined,
+          );
+        if (expectedHandle && handle !== expectedHandle) continue;
+
+        const id = numericString(e.identifier);
+        if (id) return id;
+      }
+    } catch {
+      /* malformed / unrelated JSON-LD — skip */
+    }
+  }
+  return undefined;
 }
 
 export interface FiberUser {
@@ -81,6 +141,64 @@ export interface FiberUser {
   followersCount?: number;
   followingCount?: number;
   accountAgeDays?: number;
+  viewerFollowing?: true;
+  viewerBlocking?: true;
+  viewerMuting?: true;
+  viewerFollowRequestSent?: true;
+  viewerIsSelf?: true;
+}
+
+function viewerHandle(): string | undefined {
+  const profileHref = document
+    .querySelector<HTMLAnchorElement>('[data-testid="AppTabBar_Profile_Link"]')
+    ?.getAttribute("href");
+  const fromHref = normalizeHandle(profileHref?.match(/^\/([^/?#]+)/)?.[1]);
+  if (fromHref && !NON_PROFILE.has(fromHref)) return fromHref;
+
+  const switcherText =
+    document.querySelector<HTMLElement>('[data-testid="SideNav_AccountSwitcher_Button"]')
+      ?.innerText ?? "";
+  return normalizeHandle(switcherText.match(/@([A-Za-z0-9_]{1,15})/)?.[1]);
+}
+
+function isViewerHandle(handle: string | undefined): true | undefined {
+  const viewer = viewerHandle();
+  const target = normalizeHandle(handle);
+  return viewer && target && viewer === target ? true : undefined;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function actionUserInfo(scope: Element | Document, handle?: string): Pick<
+  FiberUser,
+  "userId" | "viewerFollowing"
+> {
+  const expected = normalizeHandle(handle);
+  const mention = expected ? new RegExp(`@${escapeRegExp(expected)}\\b`, "i") : undefined;
+  for (const el of scope.querySelectorAll<HTMLElement>(
+    '[data-testid$="-follow"], [data-testid$="-unfollow"], [data-testid$="-subscribe"]',
+  )) {
+    const testid = el.getAttribute("data-testid") ?? "";
+    const match = testid.match(/^(\d+)-(follow|unfollow|subscribe)$/);
+    if (!match) continue;
+    const label = `${el.getAttribute("aria-label") ?? ""}\n${el.innerText ?? ""}`;
+    if (mention && !mention.test(label)) continue;
+    return {
+      userId: match[1],
+      ...(match[2] === "unfollow" ? { viewerFollowing: true as const } : {}),
+    };
+  }
+  if (mention) {
+    for (const el of scope.querySelectorAll<HTMLElement>('button, [role="button"]')) {
+      const label = `${el.getAttribute("aria-label") ?? ""}\n${el.innerText ?? ""}`;
+      if (mention.test(label) && /(取消关注|正在关注|Following|Unfollow)/i.test(label)) {
+        return { viewerFollowing: true as const };
+      }
+    }
+  }
+  return {};
 }
 
 /**
@@ -121,14 +239,22 @@ function readFiberUserUncached(el: Element, expectedHandle?: string): FiberUser 
           const created = legacy.created_at
             ? Date.parse(legacy.created_at)
             : NaN;
+          const userId = fiberUserId(u, legacy);
+          const accountAgeDays = Number.isNaN(created)
+            ? undefined
+            : Math.max(0, Math.round((Date.now() - created) / 86_400_000));
           return {
             bio: typeof legacy.description === "string" ? legacy.description : "",
-            userId: numericId(u.rest_id) ?? numericId(legacy.id_str),
+            ...(userId ? { userId } : {}),
             followersCount: legacy.followers_count,
             followingCount: legacy.friends_count,
-            accountAgeDays: Number.isNaN(created)
-              ? undefined
-              : Math.max(0, Math.round((Date.now() - created) / 86_400_000)),
+            ...(accountAgeDays !== undefined ? { accountAgeDays } : {}),
+            ...(trueFlag(legacy.following) ? { viewerFollowing: true as const } : {}),
+            ...(trueFlag(legacy.blocking) ? { viewerBlocking: true as const } : {}),
+            ...(trueFlag(legacy.muting) ? { viewerMuting: true as const } : {}),
+            ...(trueFlag(legacy.follow_request_sent)
+              ? { viewerFollowRequestSent: true as const }
+              : {}),
           };
         }
       }
@@ -138,6 +264,42 @@ function readFiberUserUncached(el: Element, expectedHandle?: string): FiberUser 
     /* X internals changed → graceful empty */
   }
   return {};
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: React internals are untyped
+function fiberUserId(u: any, legacy: any): string | undefined {
+  const fromLegacy = numericId(legacy?.id_str);
+  const fromRest = numericId(u?.rest_id);
+  if (fromLegacy && fromRest && fromLegacy !== fromRest) {
+    console.warn("[MXGA] conflicting X user ids in fiber; dropping uid", {
+      legacyId: fromLegacy,
+      restId: fromRest,
+      screenName: legacy?.screen_name,
+    });
+    return undefined;
+  }
+  const candidate = fromLegacy ?? fromRest;
+  const avatarId = numericId(
+    String(legacy?.profile_image_url_https ?? "").match(/profile_images\/(\d+)\//)?.[1],
+  );
+  const candidateTime = candidate ? snowflakeTimeMs(candidate) : undefined;
+  const created = typeof legacy?.created_at === "string" ? Date.parse(legacy.created_at) : NaN;
+  if (
+    candidate &&
+    avatarId === candidate &&
+    candidateTime !== undefined &&
+    !Number.isNaN(created) &&
+    Math.abs(candidateTime - created) > UID_CREATED_AT_TOLERANCE_MS
+  ) {
+    console.warn("[MXGA] fiber uid looks like avatar media id; dropping uid", {
+      candidate,
+      screenName: legacy?.screen_name,
+      createdAt: legacy.created_at,
+      avatarUrl: legacy.profile_image_url_https,
+    });
+    return undefined;
+  }
+  return candidate;
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: deep search over React internals
@@ -155,6 +317,7 @@ function findUser(
   try {
     const legacy = o.legacy ?? o;
     if (
+      o.__typename === "User" &&
       legacy &&
       typeof legacy === "object" &&
       typeof legacy.description === "string" &&
@@ -199,8 +362,26 @@ export function extractProfile(): Signals | null {
     document.querySelector('[data-testid="primaryColumn"]') ?? document;
   const { hasDefaultAvatar, avatarUrl } = avatarInfo(scope);
   const profileScope = scope instanceof Element ? scope : nameEl;
-  const fu = readFiberUser(profileScope, handle);
-  const userId = fu.userId ?? bannerUserId(scope);
+  const networkUser = readGraphqlUser(handle);
+  const actionUser = actionUserInfo(profileScope, handle);
+  const fu: KnownUser = {
+    ...readFiberUser(profileScope, handle),
+    ...networkUser,
+    ...(actionUser.userId ? { userId: actionUser.userId } : {}),
+    ...(actionUser.viewerFollowing ? { viewerFollowing: true as const } : {}),
+    ...(isViewerHandle(handle) || profileScope.querySelector('[data-testid="editProfileButton"]')
+      ? { viewerIsSelf: true as const }
+      : {}),
+  };
+  const jsonLdUserId = profileJsonLdUserId(handle);
+  if (jsonLdUserId && fu.userId && jsonLdUserId !== fu.userId) {
+    console.warn("[MXGA] profile JSON-LD user id differs from observed user id; using JSON-LD", {
+      handle,
+      jsonLdUserId,
+      observedUserId: fu.userId,
+    });
+  }
+  const userId = jsonLdUserId ?? fu.userId ?? bannerUserId(scope);
 
   return {
     isProfile: true,
@@ -211,6 +392,11 @@ export function extractProfile(): Signals | null {
     recentTweets: [],
     ...(avatarUrl ? { avatarUrl } : {}),
     ...(userId ? { userId } : {}),
+    ...(fu.viewerFollowing ? { viewerFollowing: true as const } : {}),
+    ...(fu.viewerBlocking ? { viewerBlocking: true as const } : {}),
+    ...(fu.viewerMuting ? { viewerMuting: true as const } : {}),
+    ...(fu.viewerFollowRequestSent ? { viewerFollowRequestSent: true as const } : {}),
+    ...(fu.viewerIsSelf ? { viewerIsSelf: true as const } : {}),
     ...(parseJoinDate(joinEl?.innerText) !== undefined
       ? { accountAgeDays: parseJoinDate(joinEl?.innerText) }
       : {}),
@@ -252,22 +438,38 @@ export function extractFromArticle(article: HTMLElement): Signals | null {
   if (!handle) return null;
   const tweetEl = article.querySelector<HTMLElement>('[data-testid="tweetText"]');
   const tweetText = tweetEl ? tweetEl.innerText.trim() : "";
-  // Pull the author's already-loaded profile (bio/counts/age) from X's React
-  // data — automatic, no hover, zero extra requests.
-  const fu = readFiberUser(article, handle);
+  // Prefer identities from X's own GraphQL responses; fall back to React
+  // fiber when the network cache has not seen this author yet.
+  const networkUser = readGraphqlUser(handle);
+  const fiberUser = readFiberUser(article, handle);
+  const actionUser = actionUserInfo(article, handle);
+  const fu: KnownUser = {
+    ...fiberUser,
+    ...networkUser,
+    ...(!fiberUser.userId && !networkUser.userId && actionUser.userId
+      ? { userId: actionUser.userId }
+      : {}),
+    ...(actionUser.viewerFollowing ? { viewerFollowing: true as const } : {}),
+    ...(isViewerHandle(handle) ? { viewerIsSelf: true as const } : {}),
+  };
   return {
     isProfile: false,
     handle,
-    displayName,
+    displayName: networkUser.displayName ?? displayName,
     bio: fu.bio ?? "",
     hasDefaultAvatar,
     recentTweets: tweetText ? [tweetText] : [],
-    ...(avatarUrl ? { avatarUrl } : {}),
+    ...(networkUser.avatarUrl ?? avatarUrl ? { avatarUrl: networkUser.avatarUrl ?? avatarUrl } : {}),
     ...(fu.userId ? { userId: fu.userId } : {}),
     ...(tweetText ? { triggeringComment: tweetText } : {}),
     ...(fu.accountAgeDays !== undefined ? { accountAgeDays: fu.accountAgeDays } : {}),
     ...(fu.followersCount !== undefined ? { followersCount: fu.followersCount } : {}),
     ...(fu.followingCount !== undefined ? { followingCount: fu.followingCount } : {}),
+    ...(fu.viewerFollowing ? { viewerFollowing: true as const } : {}),
+    ...(fu.viewerBlocking ? { viewerBlocking: true as const } : {}),
+    ...(fu.viewerMuting ? { viewerMuting: true as const } : {}),
+    ...(fu.viewerFollowRequestSent ? { viewerFollowRequestSent: true as const } : {}),
+    ...(fu.viewerIsSelf ? { viewerIsSelf: true as const } : {}),
   };
 }
 

--- a/extension/lib/graphql-users.ts
+++ b/extension/lib/graphql-users.ts
@@ -1,0 +1,75 @@
+export interface GraphqlUserSnapshot {
+  handle: string;
+  userId: string;
+  bio?: string;
+  displayName?: string;
+  avatarUrl?: string;
+  followersCount?: number;
+  followingCount?: number;
+  createdAt?: string;
+  viewerFollowing?: boolean;
+  viewerBlocking?: boolean;
+  viewerMuting?: boolean;
+  viewerFollowRequestSent?: boolean;
+}
+
+export interface KnownUser {
+  bio?: string;
+  userId?: string;
+  followersCount?: number;
+  followingCount?: number;
+  accountAgeDays?: number;
+  displayName?: string;
+  avatarUrl?: string;
+  viewerFollowing?: true;
+  viewerBlocking?: true;
+  viewerMuting?: true;
+  viewerFollowRequestSent?: true;
+  viewerIsSelf?: true;
+}
+
+const graphqlUserCache = new Map<string, KnownUser>();
+
+function normalizeHandle(handle: string | undefined): string | undefined {
+  return handle?.trim().replace(/^@+/, "").toLowerCase() || undefined;
+}
+
+function numericId(v: unknown): string | undefined {
+  return typeof v === "string" && /^\d+$/.test(v) ? v : undefined;
+}
+
+export function ingestGraphqlUsers(users: GraphqlUserSnapshot[]): boolean {
+  let changed = false;
+  for (const user of users) {
+    const handle = normalizeHandle(user.handle);
+    const userId = numericId(user.userId);
+    if (!handle || !userId) continue;
+    const created = user.createdAt ? Date.parse(user.createdAt) : NaN;
+    const next: KnownUser = {
+      userId,
+      ...(user.bio !== undefined ? { bio: user.bio } : {}),
+      ...(user.followersCount !== undefined ? { followersCount: user.followersCount } : {}),
+      ...(user.followingCount !== undefined ? { followingCount: user.followingCount } : {}),
+      ...(user.displayName ? { displayName: user.displayName } : {}),
+      ...(user.avatarUrl ? { avatarUrl: user.avatarUrl } : {}),
+      ...(user.viewerFollowing ? { viewerFollowing: true as const } : {}),
+      ...(user.viewerBlocking ? { viewerBlocking: true as const } : {}),
+      ...(user.viewerMuting ? { viewerMuting: true as const } : {}),
+      ...(user.viewerFollowRequestSent ? { viewerFollowRequestSent: true as const } : {}),
+      ...(Number.isNaN(created)
+        ? {}
+        : { accountAgeDays: Math.max(0, Math.round((Date.now() - created) / 86_400_000)) }),
+    };
+    const prev = graphqlUserCache.get(handle);
+    if (JSON.stringify(prev) !== JSON.stringify(next)) {
+      graphqlUserCache.set(handle, next);
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+export function readGraphqlUser(handle: string | undefined): KnownUser {
+  const key = normalizeHandle(handle);
+  return key ? (graphqlUserCache.get(key) ?? {}) : {};
+}

--- a/extension/lib/settings.ts
+++ b/extension/lib/settings.ts
@@ -12,6 +12,17 @@ export interface Settings {
    *  to click the pill to act. Toggle is also surfaced inline inside the
    *  card itself ("下次自动弹出"). */
   autoExpandOnFinding: boolean;
+  /** When true, any account the system has already concluded is spam is
+   *  silently enqueued to the paced block queue on EVERY page the user
+   *  visits — no badge, no card, no click required. Two sources count as
+   *  "system-confirmed":
+   *    - step 1 cache hit  → "cache_hit"  (this device LLM-classified it
+   *      as spam in a prior session and stored the verdict locally).
+   *    - step 2 list hit   → "list_hit"   (the public blacklist has it).
+   *  Fresh in-session LLM verdicts (step 3) still require user action so
+   *  the user has a chance to vet first-time classifications. Defaults
+   *  to OFF — the conservative choice for a Chrome Web Store rollout. */
+  autoBlockListHits: boolean;
 }
 
 export const DEFAULTS: Settings = {
@@ -21,6 +32,7 @@ export const DEFAULTS: Settings = {
   replyAuto: true,
   edgeBase: "",
   autoExpandOnFinding: true,
+  autoBlockListHits: false,
 };
 
 const KEY = "xss:settings";

--- a/extension/lib/store.ts
+++ b/extension/lib/store.ts
@@ -3,7 +3,10 @@
 // PII beyond the public numeric id (governance unchanged).
 import type { Verdict } from "./types";
 
-export type BlockSource = "manual" | "block_all" | "list_hit";
+// "list_hit"  → public-blacklist match (step 2 of content.ts)
+// "cache_hit" → local cache says this account is spam (step 1 of content.ts)
+// Both are auto-block sources that fire when settings.autoBlockListHits is on.
+export type BlockSource = "manual" | "block_all" | "list_hit" | "cache_hit";
 
 export interface BlockRecord {
   id: string; // userId, or h:<handle> fallback

--- a/extension/lib/types.ts
+++ b/extension/lib/types.ts
@@ -29,6 +29,11 @@ export interface Signals {
   accountAgeDays?: number;
   followersCount?: number;
   followingCount?: number;
+  viewerFollowing?: boolean;
+  viewerBlocking?: boolean;
+  viewerMuting?: boolean;
+  viewerFollowRequestSent?: boolean;
+  viewerIsSelf?: boolean;
 }
 
 export type BgRequest =

--- a/extension/lib/ui.ts
+++ b/extension/lib/ui.ts
@@ -7,7 +7,7 @@ import type { Label, Verdict } from "./types";
 export const STYLE = `
 :host { all: initial; }
 * { box-sizing: border-box; font-family: system-ui,-apple-system,"Segoe UI",sans-serif; }
-:root, .xss {
+:host, :root, .xss {
   /* dark default (X dark mode) */
   --surface: rgba(13,17,23,.92); --border: rgba(255,255,255,.10);
   --shadow: 0 8px 28px rgba(0,0,0,.45); --text: #E6EDF3; --muted: #8B949E;
@@ -18,7 +18,7 @@ export const STYLE = `
   --shimmer: rgba(255,255,255,.18);
 }
 @media (prefers-color-scheme: light) {
-  :root, .xss {
+  :host, :root, .xss {
     --surface: rgba(255,255,255,.96); --border: rgba(15,23,42,.12);
     --shadow: 0 8px 28px rgba(15,23,42,.18); --text: #0F172A; --muted: #475569;
     --brand: #0369A1; --danger: #DC2626; --warn: #B45309; --neutral: #475569;
@@ -38,12 +38,47 @@ export const STYLE = `
   -webkit-backdrop-filter: blur(12px); border-radius: 14px;
 }
 .pill {
-  display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px;
-  border-radius: 999px; cursor: pointer; transition: opacity .14s ease;
+  display: inline-flex; align-items: center; gap: 8px; padding: 6px 10px;
+  border-radius: 999px; cursor: pointer; transition: opacity .14s ease, transform .14s ease;
+  min-width: 0; min-height: 36px;
 }
-.pill:hover { opacity: .92; }
+.pill:hover { opacity: .94; transform: translateY(-1px); }
 .pill .n {
   font-size: 12px; font-weight: 700; min-width: 16px; text-align: center;
+}
+.scan-pill {
+  display: grid; grid-template-columns: 22px auto auto;
+  align-items: center; gap: 7px; width: auto;
+}
+.scan-radar {
+  --accent: var(--brand); --angle: 360deg;
+  width: 22px; height: 22px; position: relative; display: grid; place-items: center;
+  border-radius: 999px; flex: none;
+  background: conic-gradient(var(--accent) var(--angle), color-mix(in srgb, var(--accent) 12%, transparent) 0deg);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.scan-radar.danger { --accent: var(--danger); }
+.scan-core {
+  position: absolute; inset: 4px; display: grid; place-items: center;
+  border-radius: inherit; background: var(--surface);
+}
+.scan-sweep {
+  position: absolute; inset: 2px; border-radius: inherit; opacity: 0;
+  background: conic-gradient(from -30deg, transparent 0 64%, color-mix(in srgb, var(--accent) 58%, transparent) 76%, transparent 92%);
+}
+.scan-radar.busy .scan-sweep {
+  opacity: .95; animation: xradar 1.15s linear infinite;
+}
+.scan-radar.busy {
+  animation: xbreath 1.6s ease-in-out infinite;
+}
+.scan-title {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  max-width: 46px; font-size: 12.5px; font-weight: 750; color: var(--text);
+}
+.scan-meta {
+  flex: none; font-size: 11px; font-weight: 650; color: var(--muted);
+  font-variant-numeric: tabular-nums;
 }
 .card { width: 312px; padding: 14px; display: none; }
 .card.open { display: block; animation: in .18s ease-out; }
@@ -102,29 +137,121 @@ export const STYLE = `
 .lnk:hover { color: var(--text); }
 svg { display: block; }
 .xss-badge {
-  display: inline-flex; align-items: center; gap: 5px; margin-left: 6px;
-  padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 700;
-  vertical-align: middle; cursor: default; color: var(--text);
-  border: 1px solid var(--border);
+  --badge-color: var(--muted);
+  width: 20px; height: 20px; display: inline-grid; place-items: center;
+  margin-left: 5px; padding: 0; border-radius: 999px; font-size: 0;
+  line-height: 0; vertical-align: -4px; cursor: default; color: var(--badge-color);
+  border: 1px solid color-mix(in srgb, var(--badge-color) 42%, transparent);
+  background: color-mix(in srgb, var(--badge-color) 13%, transparent);
+  box-shadow: 0 1px 4px rgba(15,23,42,.08);
+  transition: transform .12s ease, opacity .12s ease, background .12s ease, border-color .12s ease, box-shadow .12s ease;
 }
-.xss-badge.ghost { color: var(--muted); cursor: pointer; }
-.xss-badge.ghost:hover { color: var(--text); }
+.xss-badge svg { width: 13px; height: 13px; stroke: currentColor; }
+.xss-badge.labeled {
+  width: auto; min-width: 20px; display: inline-flex; align-items: center; justify-content: center;
+  gap: 4px; padding: 0 6px; font-size: 11px; line-height: 1; font-weight: 750;
+  letter-spacing: 0; white-space: nowrap;
+}
+.xss-badge.labeled svg { width: 12px; height: 12px; flex: 0 0 auto; }
+.xss-badge .xss-ico {
+  width: 13px; height: 13px; flex: 0 0 auto; display: inline-grid; place-items: center;
+  position: relative; overflow: visible;
+}
+.xss-badge .xss-ico svg { width: 12px; height: 12px; }
+.xss-badge .xss-label { display: inline-block; }
+.xss-badge:hover {
+  transform: translateY(-1px); opacity: 1;
+  border-color: color-mix(in srgb, var(--badge-color) 64%, transparent);
+  background: color-mix(in srgb, var(--badge-color) 18%, transparent);
+  box-shadow: 0 3px 10px rgba(15,23,42,.13);
+}
+.xss-badge.ghost {
+  --badge-color: var(--brand);
+  cursor: pointer; opacity: .9;
+  border-color: color-mix(in srgb, var(--badge-color) 35%, transparent);
+  background: color-mix(in srgb, var(--badge-color) 9%, transparent);
+}
+.xss-badge.ghost:hover { opacity: .95; }
+.xss-badge.verdict.list {
+  color: #fff;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--danger) 92%, #fff), var(--danger));
+  border-color: color-mix(in srgb, var(--danger) 90%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger) 14%, transparent), 0 2px 7px color-mix(in srgb, var(--danger) 18%, transparent);
+}
+.xss-badge.verdict.fresh {
+  background: color-mix(in srgb, var(--badge-color) 16%, transparent);
+  border-color: color-mix(in srgb, var(--badge-color) 46%, transparent);
+}
+.xss-badge.verdict.fresh { animation: xrise .22s ease-out; }
+.xss-badge.verdict.spammy {
+  color: #fff;
+  --badge-color: var(--danger);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--danger) 92%, #fff), var(--danger));
+  border-color: color-mix(in srgb, var(--danger) 90%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger) 14%, transparent), 0 2px 7px color-mix(in srgb, var(--danger) 18%, transparent);
+}
+.xss-badge.verdict.spammy:hover,
+.xss-badge.verdict.list:hover {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--danger) 96%, #fff), color-mix(in srgb, var(--danger) 92%, #000));
+  border-color: var(--danger);
+}
+.xss-badge.verdict.cache {
+  opacity: .74;
+}
 .pop {
-  position: fixed; z-index: 2147482001; width: 260px; padding: 12px;
-  font-size: 12px; color: var(--text);
+  position: fixed; z-index: 2147482001; width: 280px; padding: 12px;
+  font-size: 12px; color: var(--text); border-radius: 12px;
+  box-shadow: 0 18px 48px rgba(15,23,42,.22), 0 2px 8px rgba(15,23,42,.10);
+  transform-origin: 12px 12px; animation: xpop .14s ease-out;
+  pointer-events: auto;
 }
-.pop h4 { margin: 0 0 6px; font-size: 12px; font-weight: 700; }
+.pop h4 { margin: 0 0 6px; font-size: 12.5px; font-weight: 750; }
 .pop ul { margin: 6px 0; padding-left: 16px; color: var(--muted); }
 .pop li { margin: 3px 0; }
-.acts { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.acts { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
 .acts button {
   border: 1px solid var(--border); background: transparent; color: var(--text);
-  border-radius: 8px; padding: 4px 9px; font-size: 11px; cursor: pointer;
+  border-radius: 999px; padding: 5px 10px; font-size: 11px; font-weight: 650;
+  cursor: pointer; transition: transform .12s ease, background .12s ease, border-color .12s ease, color .12s ease, filter .12s ease;
 }
-.acts button:hover { background: var(--hover); }
+.acts button:hover {
+  transform: translateY(-1px);
+  background: var(--hover);
+}
+.acts button[data-c] {
+  color: var(--brand);
+  border-color: color-mix(in srgb, var(--brand) 42%, var(--border));
+  background: color-mix(in srgb, var(--brand) 8%, transparent);
+}
+.acts button[data-r] {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 48%, var(--border));
+  background: color-mix(in srgb, var(--warn) 9%, transparent);
+}
+.acts button[data-b] {
+  color: #fff; border-color: transparent;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--danger) 92%, #fff), var(--danger));
+}
+.acts button[data-h] {
+  color: var(--muted);
+  border-color: color-mix(in srgb, var(--muted) 32%, var(--border));
+}
+.acts button[data-a] {
+  color: var(--muted);
+  border-color: transparent;
+}
+.acts button[data-b]:hover { filter: brightness(1.05); }
+.acts button:disabled {
+  cursor: default; transform: none; filter: none;
+}
+.acts button.done {
+  color: #fff; border-color: transparent; background: var(--safe);
+}
+.acts button.err {
+  color: #fff; border-color: transparent; background: var(--danger);
+}
 
 /* ---- animated badge states (transform/opacity only) ---- */
-.xss-badge.fresh { animation: xrise .22s ease-out; }
 .xss-badge.known { animation: xpop .18s ease-out; }
 .xss-badge .kdot {
   width: 6px; height: 6px; border-radius: 50%; background: var(--brand);
@@ -150,22 +277,25 @@ svg { display: block; }
 .xss-badge .stag.fresh { color: var(--warn); border: 1px solid var(--warn); }
 /* Whitelist badge — green checkmark, no popover content beyond the badge itself */
 .xss-badge.whitelist {
-  color: var(--safe); border-color: var(--safe);
+  --badge-color: var(--safe);
+  background: color-mix(in srgb, var(--badge-color) 16%, transparent);
+  border-color: color-mix(in srgb, var(--badge-color) 50%, transparent);
 }
 .xss-badge.whitelist .wdot {
   width: 6px; height: 6px; border-radius: 50%; background: var(--safe); flex: none;
 }
 .xss-badge.analyzing {
-  color: var(--muted); position: relative; overflow: hidden;
+  --badge-color: var(--brand);
+  overflow: visible;
 }
-.xss-badge.analyzing::after {
-  content: ""; position: absolute; inset: 0;
-  background: linear-gradient(90deg, transparent, var(--shimmer), transparent);
-  transform: translateX(-100%); animation: xshim 1.1s ease-in-out infinite;
+.xss-badge.analyzing .xss-ico::after {
+  content: ""; position: absolute; inset: -3px; border-radius: 999px;
+  border: 1.5px solid transparent; border-top-color: var(--badge-color);
+  animation: xspin .7s linear infinite;
 }
-.xss-spin { animation: xspin .8s linear infinite; transform-origin: 50% 50%; }
 .xss-badge.pending {
-  color: var(--muted); cursor: default;
+  --badge-color: var(--muted);
+  cursor: default;
   animation: xpulse 1.6s ease-in-out infinite;
 }
 @keyframes xrise { from { opacity: 0; transform: translateY(4px); } }
@@ -173,38 +303,64 @@ svg { display: block; }
 @keyframes xspin { to { transform: rotate(360deg); } }
 @keyframes xshim { to { transform: translateX(100%); } }
 @keyframes xpulse { 0%,100% { opacity: .55; } 50% { opacity: .95; } }
+@keyframes xradar { to { transform: rotate(360deg); } }
+@keyframes xbreath { 0%,100% { filter: saturate(1); } 50% { filter: saturate(1.35); } }
 
-/* refined attention flash when a NEW spam account is found */
-.pill.flash { animation: xflash 1s ease-out 2; }
-@keyframes xflash {
-  0% { box-shadow: var(--shadow); transform: scale(1); }
-  18% { box-shadow: 0 0 0 4px rgba(239,68,68,.35), var(--shadow); transform: scale(1.06); }
-  60% { box-shadow: 0 0 0 0 rgba(239,68,68,0), var(--shadow); transform: scale(1); }
-  100% { box-shadow: var(--shadow); transform: scale(1); }
+/* New-hit motion: one compact radar lap, slow at first then faster. */
+.pill.hit-pulse .scan-radar {
+  animation: xhitspin .82s cubic-bezier(.62, 0, 1, .62) 1, xhitglow .9s ease-out 1;
+}
+@keyframes xhitspin {
+  0% { transform: rotate(0deg) scale(1); }
+  42% { transform: rotate(72deg) scale(1.08); }
+  100% { transform: rotate(360deg) scale(1); }
+}
+@keyframes xhitglow {
+  0% { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent), 0 0 0 0 color-mix(in srgb, var(--accent) 0%, transparent); }
+  32% { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent), 0 0 0 5px color-mix(in srgb, var(--accent) 18%, transparent); }
+  100% { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent), 0 0 0 0 color-mix(in srgb, var(--accent) 0%, transparent); }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .card.open { animation: fade .18s ease-out; }
   @keyframes fade { from { opacity: 0; } }
   .xss-badge.fresh, .xss-badge.known { animation: fade .18s ease-out; }
-  .xss-badge.analyzing::after, .xss-spin { animation: none; }
+  .xss-badge.analyzing .xss-ico::after, .scan-radar.busy, .scan-radar.busy .scan-sweep { animation: none; }
   .xss-badge.pending { animation: none; opacity: .7; }
-  .pill.flash { animation: none; }
+  .pill.hit-pulse .scan-radar { animation: none; }
+}
+@media (max-width: 720px) {
+  .xss-badge.labeled {
+    width: 20px; padding: 0; gap: 0;
+  }
+  .xss-badge.labeled .xss-label { display: none; }
 }
 `;
 
 // Lucide-style 24-viewBox stroke icons. No emoji (per design system).
-const P: Record<string, string> = {
-  shield: "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z",
-  "shield-alert": "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10zM12 8v4M12 16h.01",
-  "shield-x": "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10zM9.5 9.5l5 5M14.5 9.5l-5 5",
-  "shield-check": "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10zM9 12l2 2 4-4",
-  x: "M18 6 6 18M6 6l12 12",
+const P: Record<string, string[]> = {
+  shield: ["M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"],
+  "shield-alert": [
+    "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z",
+    "M12 8v4",
+    "M12 16h.01",
+  ],
+  "shield-x": [
+    "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z",
+    "M9.5 9.5l5 5",
+    "M14.5 9.5l-5 5",
+  ],
+  "shield-check": [
+    "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z",
+    "M9 12l2 2 4-4",
+  ],
+  x: ["M18 6 6 18", "M6 6l12 12"],
 };
 export function icon(name: keyof typeof P | string, color = "currentColor", size = 16): string {
+  const paths = P[name] ?? P.shield ?? [];
   return `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none"
-    stroke="${color}" stroke-width="1.75" stroke-linecap="round"
-    stroke-linejoin="round" aria-hidden="true"><path d="${P[name] ?? P.shield}"/></svg>`;
+    stroke="${color}" stroke-width="2.15" stroke-linecap="round"
+    stroke-linejoin="round" aria-hidden="true">${paths.map((d) => `<path d="${d}"/>`).join("")}</svg>`;
 }
 
 export const LABEL: Record<Label, { zh: string; varName: string; ic: string }> = {
@@ -213,6 +369,35 @@ export const LABEL: Record<Label, { zh: string; varName: string; ic: string }> =
   likely_spam: { zh: "疑似垃圾", varName: "--warn", ic: "shield-alert" },
   uncertain: { zh: "不确定", varName: "--neutral", ic: "shield" },
   legit: { zh: "正常", varName: "--safe", ic: "shield-check" },
+};
+
+/**
+ * HTML-escape any string we interpolate into innerHTML inside our Shadow
+ * DOMs. The popover and card bodies render content sourced from:
+ *   - X's own backend (display names, bios, avatar URLs) — usually safe but
+ *     attacker-controlled at the source.
+ *   - Our LLM Worker's `reasons` array — text we asked the model to write,
+ *     so technically prompt-injectable via a malicious user's bio.
+ * Neither source is allowed to reach innerHTML un-escaped. Shadow DOM does
+ * NOT sandbox script execution: an `<img src=x onerror=...>` injected into
+ * a content-script shadow root still runs in the isolated world, which has
+ * chrome.storage / chrome.runtime / first-party x.com fetch access. So we
+ * keep this strict and use it everywhere user-derived text touches HTML.
+ */
+function escHtml(s: string): string {
+  return s.replace(
+    /[<>&"']/g,
+    (c) =>
+      ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;", "'": "&#39;" })[c] ?? c,
+  );
+}
+
+const BADGE_TEXT: Record<Label, string> = {
+  spam: "垃圾",
+  porn_bot: "色情",
+  likely_spam: "疑似",
+  uncertain: "存疑",
+  legit: "正常",
 };
 
 export interface Finding {
@@ -267,22 +452,67 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
       ? "--danger"
       : "--warn";
 
+  function progressMarkup(opts: {
+    iconName: string;
+    iconColor: string;
+    title: string;
+    count?: string;
+    percent: number;
+    busy?: boolean;
+    danger?: boolean;
+  }) {
+    const percent = Math.max(0, Math.min(100, opts.percent));
+    const angle = Math.round(percent * 3.6);
+    return `<span class="scan-pill">
+      <span class="scan-radar ${opts.busy ? "busy" : ""} ${opts.danger ? "danger" : ""}" style="--angle:${angle}deg">
+        <span class="scan-sweep"></span>
+        <span class="scan-core">${icon(opts.iconName, opts.iconColor, 11)}</span>
+      </span>
+      <span class="scan-title">${opts.title}</span>
+      ${opts.count ? `<span class="scan-meta">${opts.count}</span>` : ""}
+    </span>`;
+  }
+
   function renderPill() {
+    const total = scanned + scanning;
+    const progress = scanning > 0
+      ? Math.max(8, Math.round((scanned / Math.max(1, total)) * 100))
+      : scanned > 0
+        ? 100
+        : 0;
     // Spammy findings present → alarm tone takes priority, shows count.
     if (findings.length) {
       const c = `var(${sev(findings)})`;
-      const trail = scanning > 0 ? ` · 还在查 ${scanning}` : "";
-      pill.innerHTML = `${icon("shield-alert", c, 16)}<span class="n">${findings.length}${trail}</span>`;
+      pill.innerHTML = progressMarkup({
+        iconName: "shield-alert",
+        iconColor: c,
+        title: "命中",
+        count: String(findings.length),
+        percent: progress || 100,
+        busy: scanning > 0,
+        danger: true,
+      });
       return;
     }
-    // Active scanning, nothing flagged yet → "已扫 X · 查 Y"
+    // Active scanning, nothing flagged yet.
     if (scanning > 0 || scanned > 0) {
-      const trail = scanning > 0 ? ` · 查 ${scanning}` : "";
-      pill.innerHTML = `${icon("shield", "var(--brand)", 16)}<span class="n" style="font-weight:600;color:var(--muted)">已扫 ${scanned}${trail}</span>`;
+      pill.innerHTML = progressMarkup({
+        iconName: scanning > 0 ? "shield" : "shield-check",
+        iconColor: "var(--brand)",
+        title: scanning > 0 ? "扫描" : "已扫",
+        count: String(scanning > 0 ? scanning : scanned),
+        percent: progress,
+        busy: scanning > 0,
+      });
       return;
     }
     // Calm "guarding" — page is idle, no signal in either direction.
-    pill.innerHTML = `${icon("shield-check", "var(--brand)", 16)}<span class="n" style="font-weight:600;color:var(--muted)">守护中</span>`;
+    pill.innerHTML = progressMarkup({
+      iconName: "shield-check",
+      iconColor: "var(--brand)",
+      title: "守护",
+      percent: 100,
+    });
   }
 
   function renderCard() {
@@ -322,16 +552,15 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
           .map((f) => {
             const m = LABEL[f.verdict.label];
             const col = `var(${m.varName})`;
+            // X serves avatar URLs as https://pbs.twimg.com/profile_images/...
+            // We still defense-in-depth escape the URL because attacker-
+            // controlled fields shouldn't reach attribute context raw.
             const av = f.avatarUrl
-              ? `<img src="${f.avatarUrl}" width="26" height="26" style="border-radius:50%;flex:none" alt="">`
+              ? `<img src="${escHtml(f.avatarUrl)}" width="26" height="26" style="border-radius:50%;flex:none" alt="">`
               : `<span style="width:26px;height:26px;border-radius:50%;flex:none;background:var(--border)"></span>`;
-            const esc = (s: string) =>
-              s.replace(/[<>&"]/g, (c) =>
-                ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" })[c] ?? c,
-              );
-            const name = esc(f.displayName?.trim() || `@${f.handle}`);
+            const name = escHtml(f.displayName?.trim() || `@${f.handle}`);
             const snip = f.snippet
-              ? esc(f.snippet.replace(/\s+/g, " ").trim()).slice(0, 60)
+              ? escHtml(f.snippet.replace(/\s+/g, " ").trim()).slice(0, 60)
               : "";
             const id = f.userId || `h:${f.handle}`;
             const checked = f.blocked ? false : f.selected !== false;
@@ -343,14 +572,14 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
             const actText = f.blocked ? "已拉黑" : f.blockFailed ? "重试" : "拉黑";
             return `<div style="display:flex;align-items:flex-start;gap:8px;padding:6px 4px">
               <input type="checkbox" class="xss-row-cb" data-sel="${id}"
-                aria-label="选中 @${esc(f.handle)}"
+                aria-label="选中 @${escHtml(f.handle)}"
                 ${checked ? "checked" : ""} ${f.blocked ? "disabled" : ""}>
               ${av}
               <div style="min-width:0;flex:1">
                 <div style="font-weight:600;font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap${f.blocked ? ";text-decoration:line-through;opacity:.55" : ""}">${name}</div>
-                <div style="font-size:11px;color:${col}">@${esc(f.handle)} · ${m.zh} ${(f.verdict.confidence * 100).toFixed(0)}%</div>
+                <div style="font-size:11px;color:${col}">@${escHtml(f.handle)} · ${m.zh} ${(f.verdict.confidence * 100).toFixed(0)}%</div>
                 ${snip ? `<div style="font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap${f.blocked ? ";text-decoration:line-through;opacity:.55" : ""}">${snip}</div>` : ""}
-                ${f.blockFailed ? `<div style="font-size:11px;color:var(--warn)">自动屏蔽失败 · <a href="https://x.com/${esc(f.handle)}" target="_blank" rel="noopener" style="color:var(--warn)">手动屏蔽</a></div>` : ""}
+                ${f.blockFailed ? `<div style="font-size:11px;color:var(--warn)">自动屏蔽失败 · <a href="https://x.com/${escHtml(f.handle)}" target="_blank" rel="noopener" style="color:var(--warn)">手动屏蔽</a></div>` : ""}
                 ${f.blocked ? `<div style="font-size:11px;color:var(--safe)">✓ 已拉黑</div>` : ""}
               </div>
               <button class="${actClass}" data-one="${id}"${f.blocked ? " disabled" : ""}>${actText}</button>
@@ -446,11 +675,11 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
       renderPill();
       if (open) renderCard();
       if (grew) {
-        // refined double flash on a newly-found spam account
-        pill.classList.remove("flash");
+        // New finding: replay one compact radar lap without resizing the pill.
+        pill.classList.remove("hit-pulse");
         void pill.offsetWidth; // restart the animation
-        pill.classList.add("flash");
-        setTimeout(() => pill.classList.remove("flash"), 2100);
+        pill.classList.add("hit-pulse");
+        setTimeout(() => pill.classList.remove("hit-pulse"), 950);
       }
     },
     setScanning(n: number) {
@@ -470,9 +699,10 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
 export interface BadgeActions {
   onBlock: () => void;
   onHide: () => void;
-  onReport: () => void;
+  onReport: () => void | Promise<void>;
   onAppeal: () => void;
   onCheck?: () => void; // present => ghost manual-check state
+  canReport?: boolean;
 }
 
 /** Inline pill on the author row; hover/focus → popover with reasons. */
@@ -484,15 +714,88 @@ export interface BadgeActions {
  *  - `fresh`     → just classified by the AI this session → amber AI tag */
 export type BadgeSource = "fresh" | "list" | "cache" | "whitelist";
 
+type PopPoint = { x: number; y: number };
+let popoverShadow: ShadowRoot | null = null;
+
+function getPopoverRoot(): ShadowRoot {
+  if (popoverShadow && popoverShadow.host.isConnected) return popoverShadow;
+  const host = document.createElement("mxga-popovers");
+  host.style.position = "fixed";
+  host.style.inset = "0";
+  host.style.width = "0";
+  host.style.height = "0";
+  host.style.zIndex = "2147482001";
+  host.style.pointerEvents = "none";
+  host.style.overflow = "visible";
+  const root = host.attachShadow({ mode: "open" });
+  const st = document.createElement("style");
+  st.textContent = STYLE;
+  root.append(st);
+  (document.documentElement || document.body).appendChild(host);
+  popoverShadow = root;
+  return root;
+}
+
+function popPoint(ev: Event | undefined, el: HTMLElement): PopPoint {
+  if (ev instanceof MouseEvent) return { x: ev.clientX, y: ev.clientY };
+  const r = el.getBoundingClientRect();
+  return { x: r.left + r.width / 2, y: r.bottom };
+}
+
+function placePopover(pop: HTMLElement, point: PopPoint): void {
+  const pad = 8;
+  const gap = 10;
+  pop.style.left = `${Math.round(point.x + gap)}px`;
+  pop.style.top = `${Math.round(point.y + gap)}px`;
+  requestAnimationFrame(() => {
+    const r = pop.getBoundingClientRect();
+    const width = r.width || pop.offsetWidth || 280;
+    const height = r.height || pop.offsetHeight || 120;
+    let left = point.x + gap;
+    let top = point.y + gap;
+    if (left + width + pad > window.innerWidth) left = point.x - width - gap;
+    if (top + height + pad > window.innerHeight) top = point.y - height - gap;
+    const maxLeft = Math.max(pad, window.innerWidth - width - pad);
+    const maxTop = Math.max(pad, window.innerHeight - height - pad);
+    pop.style.left = `${Math.round(Math.min(Math.max(pad, left), maxLeft))}px`;
+    pop.style.top = `${Math.round(Math.min(Math.max(pad, top), maxTop))}px`;
+  });
+}
+
+async function runReportButton(btn: HTMLButtonElement, action: () => void | Promise<void>) {
+  if (btn.disabled) return;
+  const original = btn.textContent || "上报";
+  btn.disabled = true;
+  btn.classList.remove("done", "err");
+  btn.textContent = "上报中";
+  btn.title = "";
+  try {
+    await action();
+    btn.classList.add("done");
+    btn.textContent = "已上报";
+  } catch (e) {
+    btn.disabled = false;
+    btn.classList.add("err");
+    btn.textContent = "失败";
+    btn.title = e instanceof Error ? e.message : String(e);
+    window.setTimeout(() => {
+      btn.classList.remove("err");
+      btn.textContent = original;
+    }, 1800);
+  }
+}
+
 /** Animated transient states for newly-found accounts. */
 export function createStatusBadge(kind: "analyzing" | "pending"): HTMLElement {
   const el = document.createElement("span");
   if (kind === "analyzing") {
-    el.className = "xss-badge analyzing";
-    el.innerHTML = `<span class="xss-spin">${icon("shield", "var(--brand)", 13)}</span><span>分析中…</span>`;
+    el.className = "xss-badge analyzing labeled";
+    el.setAttribute("aria-label", "MXGA 正在分析");
+    el.innerHTML = `<span class="xss-ico">${icon("shield", "currentColor", 12)}</span><span class="xss-label">分析</span>`;
   } else {
-    el.className = "xss-badge pending";
-    el.innerHTML = `${icon("shield", "currentColor", 13)}<span>排队检测…</span>`;
+    el.className = "xss-badge pending labeled";
+    el.setAttribute("aria-label", "MXGA 排队检测");
+    el.innerHTML = `<span class="xss-ico">${icon("shield", "currentColor", 12)}</span><span class="xss-label">排队</span>`;
   }
   return el;
 }
@@ -509,22 +812,83 @@ export function createBadge(
   // Doesn't pop a verdict card; the user just needs to know "this account is
   // explicitly vetted, don't worry about it".
   if (source === "whitelist") {
-    el.className = "xss-badge whitelist";
-    el.title = "MXGA 维护者已确认安全（白名单）";
-    el.innerHTML = `<span class="wdot"></span>${icon("shield-check", "var(--safe)", 13)}<span>白名单</span>`;
+    el.className = "xss-badge whitelist labeled";
+    el.setAttribute("aria-label", "MXGA 维护者已确认安全（白名单）");
+    el.innerHTML = `<span class="xss-ico">${icon("shield-check", "currentColor", 12)}</span><span class="xss-label">白名单</span>`;
     return el;
   }
   if (!v) {
-    el.className = "xss-badge ghost";
-    el.innerHTML = `${icon("shield", "currentColor", 13)}<span>检查</span>`;
-    el.addEventListener("click", () => a.onCheck?.());
+    el.className = "xss-badge ghost labeled";
+    el.setAttribute("aria-label", a.canReport ? "MXGA：检查、上报或拉黑并上报" : "MXGA 手动检查");
+    el.innerHTML = `<span class="xss-ico">${icon("shield", "currentColor", 12)}</span><span class="xss-label">检查</span>`;
+    if (!a.canReport) {
+      el.addEventListener("click", () => a.onCheck?.());
+      return el;
+    }
+    let manualPop: HTMLElement | null = null;
+    let manualHideTimer: number | undefined;
+    const hideManual = () => {
+      if (manualHideTimer) window.clearTimeout(manualHideTimer);
+      manualHideTimer = undefined;
+      manualPop?.remove();
+      manualPop = null;
+    };
+    const cancelManualHide = () => {
+      if (manualHideTimer) window.clearTimeout(manualHideTimer);
+      manualHideTimer = undefined;
+    };
+    const scheduleManualHide = () => {
+      cancelManualHide();
+      manualHideTimer = window.setTimeout(hideManual, 180);
+    };
+    const showManual = (ev?: Event) => {
+      cancelManualHide();
+      if (!manualPop) {
+        manualPop = document.createElement("div");
+        manualPop.className = "xss pop card";
+        manualPop.style.display = "block";
+        manualPop.innerHTML = `
+          <h4>手动处理</h4>
+          <div style="color:var(--muted);line-height:1.55">未命中公榜时，可主动检查；确认可疑后再上报或拉黑并上报。</div>
+          <div class="acts">
+            <button data-c>检查</button>
+            <button data-r>上报</button>
+            <button data-b>拉黑并上报</button>
+          </div>`;
+        manualPop.querySelector("[data-c]")?.addEventListener("click", () => {
+          a.onCheck?.();
+          hideManual();
+        });
+        manualPop.querySelector<HTMLButtonElement>("[data-r]")?.addEventListener("click", (ev) => {
+          ev.stopPropagation();
+          const btn = ev.currentTarget as HTMLButtonElement;
+          void runReportButton(btn, a.onReport).then(() => {
+            if (btn.classList.contains("done")) window.setTimeout(hideManual, 600);
+          });
+        });
+        manualPop.querySelector("[data-b]")?.addEventListener("click", () => {
+          a.onBlock();
+          hideManual();
+        });
+        manualPop.addEventListener("mouseenter", cancelManualHide);
+        manualPop.addEventListener("mouseleave", scheduleManualHide);
+        getPopoverRoot().appendChild(manualPop);
+      }
+      placePopover(manualPop, popPoint(ev, el));
+    };
+    el.addEventListener("click", showManual);
+    el.addEventListener("mouseenter", showManual);
+    el.addEventListener("focus", showManual);
+    el.addEventListener("mouseleave", scheduleManualHide);
+    el.addEventListener("blur", scheduleManualHide);
     return el;
   }
   const meta = LABEL[v.label];
-  const color = `var(${meta.varName})`;
   const known = source === "list" || source === "cache";
-  el.className = `xss-badge ${known ? "known" : "fresh"}`;
-  el.style.borderColor = color;
+  const spammy = v.label === "spam" || v.label === "porn_bot" || v.label === "likely_spam";
+  const color = spammy ? "var(--danger)" : `var(${meta.varName})`;
+  el.className = `xss-badge labeled verdict ${source} ${spammy ? "spammy" : ""} ${known ? "known" : "fresh"}`;
+  el.style.setProperty("--badge-color", color);
   // Tier-specific tooltip + tag — tells the user exactly which gate matched.
   const tip =
     source === "list"
@@ -532,51 +896,63 @@ export function createBadge(
       : source === "cache"
         ? "本地缓存命中：本机之前已经判过这个号"
         : "AI 现场判定：本次会话首次扫描，已记录待人工确认";
-  el.title = tip;
-  const mark = known
-    ? `<span class="kdot" title="${tip}"></span>`
-    : `<span class="ndot" title="${tip}"></span>`;
-  // Source-tier mini-tag. Spammy badges only — legit verdicts don't need the
-  // origin call-out (a "legit · 公榜" badge would be confusing).
-  const spammy = v.label === "spam" || v.label === "porn_bot" || v.label === "likely_spam";
-  const tagText = source === "list" ? "公榜" : source === "cache" ? "缓存" : "AI";
-  const tag = spammy
-    ? `<span class="stag ${source}" title="${tip}">${tagText}</span>`
-    : "";
-  el.innerHTML =
-    `${mark}${icon(meta.ic, color, 13)}<span style="color:${color}">${meta.zh} ${(v.confidence * 100).toFixed(0)}%</span>${tag}`;
+  el.setAttribute("aria-label", `${tip}：${meta.zh} ${(v.confidence * 100).toFixed(0)}%`);
+  const badgeText = source === "list" ? "公榜" : BADGE_TEXT[v.label];
+  el.innerHTML = `<span class="xss-ico">${icon(meta.ic, "currentColor", 12)}</span><span class="xss-label">${badgeText}</span>`;
 
   let pop: HTMLElement | null = null;
-  const show = () => {
-    if (pop) return;
-    pop = document.createElement("div");
-    pop.className = "xss pop card";
-    pop.style.display = "block";
-    const spammy = ["spam", "porn_bot", "likely_spam"].includes(v.label);
-    pop.innerHTML = `
-      <h4 style="color:${color}">${meta.zh} · ${(v.confidence * 100).toFixed(0)}%</h4>
-      <ul>${v.reasons.map((r) => `<li>${r}</li>`).join("")}</ul>
-      ${note ? `<div style="color:var(--muted)">${note}</div>` : ""}
-      <div class="acts">
-        ${spammy ? '<button data-b>拉黑</button><button data-h>隐藏</button>' : ""}
-        <button data-r>上报</button><button data-a>误判?</button>
-      </div>`;
-    const r = el.getBoundingClientRect();
-    pop.style.left = `${Math.max(8, r.left)}px`;
-    pop.style.top = `${r.bottom + 6}px`;
-    pop.querySelector("[data-b]")?.addEventListener("click", a.onBlock);
-    pop.querySelector("[data-h]")?.addEventListener("click", a.onHide);
-    pop.querySelector("[data-r]")?.addEventListener("click", a.onReport);
-    pop.querySelector("[data-a]")?.addEventListener("click", a.onAppeal);
-    el.getRootNode().appendChild?.(pop);
-  };
+  let hideTimer: number | undefined;
   const hide = () => {
+    if (hideTimer) window.clearTimeout(hideTimer);
+    hideTimer = undefined;
     pop?.remove();
     pop = null;
   };
+  const cancelHide = () => {
+    if (hideTimer) window.clearTimeout(hideTimer);
+    hideTimer = undefined;
+  };
+  const scheduleHide = () => {
+    cancelHide();
+    hideTimer = window.setTimeout(hide, 160);
+  };
+  const show = (ev?: Event) => {
+    cancelHide();
+    if (!pop) {
+      pop = document.createElement("div");
+      pop.className = "xss pop card";
+      pop.style.display = "block";
+      const spammy = ["spam", "porn_bot", "likely_spam"].includes(v.label);
+      // reasons come from the LLM Worker — technically prompt-injectable via
+      // a malicious user's bio. Escape unconditionally. note is a server-
+      // controlled debug string ("数字ID未解析…") but escape it too for
+      // consistency with the rest of the popover.
+      pop.innerHTML = `
+        <h4 style="color:${color}">${meta.zh} · ${(v.confidence * 100).toFixed(0)}%</h4>
+        <ul>${v.reasons.map((r) => `<li>${escHtml(r)}</li>`).join("")}</ul>
+        ${note ? `<div style="color:var(--muted)">${escHtml(note)}</div>` : ""}
+        <div class="acts">
+          ${spammy ? '<button data-b>拉黑</button><button data-h>隐藏</button>' : ""}
+          ${a.canReport ? '<button data-r>上报</button>' : ""}
+          <button data-a>误判?</button>
+        </div>`;
+      pop.querySelector("[data-b]")?.addEventListener("click", a.onBlock);
+      pop.querySelector("[data-h]")?.addEventListener("click", a.onHide);
+      pop.querySelector<HTMLButtonElement>("[data-r]")?.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        void runReportButton(ev.currentTarget as HTMLButtonElement, a.onReport);
+      });
+      pop.querySelector("[data-a]")?.addEventListener("click", a.onAppeal);
+      pop.addEventListener("mouseenter", cancelHide);
+      pop.addEventListener("mouseleave", scheduleHide);
+      getPopoverRoot().appendChild(pop);
+    }
+    placePopover(pop, popPoint(ev, el));
+  };
+  el.addEventListener("click", show);
   el.addEventListener("mouseenter", show);
   el.addEventListener("focus", show);
-  el.addEventListener("mouseleave", () => setTimeout(hide, 120));
-  el.addEventListener("blur", hide);
+  el.addEventListener("mouseleave", scheduleHide);
+  el.addEventListener("blur", scheduleHide);
   return el;
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mxga-extension",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Make X Great Again (MXGA) — passive ambient X browser extension (WXT, MV3).",
   "license": "AGPL-3.0-only",

--- a/services/edge/src/index.ts
+++ b/services/edge/src/index.ts
@@ -100,6 +100,11 @@ const Signals = z.object({
   followingCount: z.number().optional(),
   hasDefaultAvatar: z.boolean().optional(),
   avatarUrl: z.string().optional(),
+  viewerFollowing: z.boolean().optional(),
+  viewerBlocking: z.boolean().optional(),
+  viewerMuting: z.boolean().optional(),
+  viewerFollowRequestSent: z.boolean().optional(),
+  viewerIsSelf: z.boolean().optional(),
 });
 type Signals = z.infer<typeof Signals>;
 
@@ -189,6 +194,16 @@ function normalizeHandle(handle: string): string {
 
 function evidenceText(s: Signals): string | null {
   return (s.triggeringComment ?? s.recentTweets[0] ?? s.bio ?? "").trim().slice(0, 240) || null;
+}
+
+function viewerScopedIgnore(s: Signals): boolean {
+  return !!(
+    s.viewerIsSelf ||
+    s.viewerFollowing ||
+    s.viewerBlocking ||
+    s.viewerMuting ||
+    s.viewerFollowRequestSent
+  );
 }
 
 interface AccountRow {
@@ -604,6 +619,16 @@ app.post("/v1/classify", async (c) => {
   if (!who) return c.json({ error: "github_login_required" }, 401);
   const parsed = Signals.parse(await c.req.json());
   const s: Signals = { ...parsed, handle: normalizeHandle(parsed.handle) };
+  if (viewerScopedIgnore(s)) {
+    return c.json({
+      cached: true,
+      ignored: true,
+      record: {
+        verdict: { label: "legit", confidence: 1, reasons: ["viewer-scoped ignored"] },
+        status: "viewer_ignored",
+      },
+    });
+  }
   const h = sigHash(s);
   const uid = s.userId ?? null;
   const prev = await findAccount(c.env, s.handle, uid);
@@ -721,6 +746,9 @@ async function submitReport(c: Ctx, source: string) {
   if (!who) return c.json({ error: "github_login_required" }, 401);
   const parsed = Signals.parse(await c.req.json());
   const s: Signals = { ...parsed, handle: normalizeHandle(parsed.handle) };
+  if (viewerScopedIgnore(s)) {
+    return c.json({ ok: true, status: "viewer_ignored", reporters: 0, auto: false, ignored: true });
+  }
   const uid = s.userId ?? null;
   const now = Date.now();
 

--- a/test/uid-detection.test.ts
+++ b/test/uid-detection.test.ts
@@ -1,0 +1,113 @@
+// Regression coverage for the uid-detection helpers shipped on fix/uid-real-rest-id.
+// These ride a Chrome Web Store release, so the contract — what changes the
+// cache, what is silently dropped — must stay stable. Only the public surface
+// (`ingestGraphqlUsers`) is tested; the DOM-bound helpers (`extractProfile`,
+// `extractFromArticle`, `readFiberUser`) need a browser fixture and live in
+// the manual smoke checklist.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const { ingestGraphqlUsers } = await import("../extension/lib/graphql-users.ts");
+
+// All tests below use unique handles per assertion so the module-level
+// graphqlUserCache (Map) does not leak state between tests.
+function uniqueHandle(tag: string): string {
+  return `mxgaTest_${tag}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+test("ingestGraphqlUsers: returns true when a fresh user lands in the cache", () => {
+  const handle = uniqueHandle("fresh");
+  const changed = ingestGraphqlUsers([
+    {
+      handle,
+      userId: "44196397",
+      bio: "hi",
+      followersCount: 200_000_000,
+      followingCount: 100,
+      createdAt: "Tue Jun 02 20:12:29 +0000 2009",
+    },
+  ]);
+  assert.equal(changed, true);
+});
+
+test("ingestGraphqlUsers: returns false when re-ingesting the same payload", () => {
+  const handle = uniqueHandle("dup");
+  const payload = [{ handle, userId: "123456789", bio: "" }];
+  assert.equal(ingestGraphqlUsers(payload), true);
+  assert.equal(ingestGraphqlUsers(payload), false);
+});
+
+test("ingestGraphqlUsers: returns true when ANY user in the batch changed", () => {
+  const stable = uniqueHandle("stable");
+  const fresh = uniqueHandle("fresh");
+  ingestGraphqlUsers([{ handle: stable, userId: "111" }]);
+  // Re-send the stable one + a brand new one in the same call.
+  const changed = ingestGraphqlUsers([
+    { handle: stable, userId: "111" },
+    { handle: fresh, userId: "222" },
+  ]);
+  assert.equal(changed, true);
+});
+
+test("ingestGraphqlUsers: silently skips entries with missing or non-numeric userId", () => {
+  const handleA = uniqueHandle("nouid");
+  const handleB = uniqueHandle("bad");
+  const handleC = uniqueHandle("nohandle");
+  const changed = ingestGraphqlUsers([
+    // Empty userId — must skip.
+    { handle: handleA, userId: "" },
+    // Non-numeric userId (e.g. someone mistakenly passed the handle) — must skip.
+    { handle: handleB, userId: "elonmusk" },
+    // Missing handle — must skip.
+    { handle: "", userId: "12345" },
+    // Missing handle (only @ characters) — must skip.
+    { handle: "@@", userId: "67890" },
+    // Empty everything — must skip.
+    { handle: "", userId: "" },
+    // ...and an out-of-range "userId" wrapped as handle — must skip.
+    { handle: handleC, userId: "abc123" },
+  ]);
+  assert.equal(changed, false);
+});
+
+test("ingestGraphqlUsers: dedupes by lowercased handle", () => {
+  const handle = uniqueHandle("Mixed");
+  // First ingest with mixed case.
+  assert.equal(ingestGraphqlUsers([{ handle, userId: "555" }]), true);
+  // Same handle in different case + same uid → no change (handle is normalized).
+  assert.equal(ingestGraphqlUsers([{ handle: handle.toUpperCase(), userId: "555" }]), false);
+});
+
+test("ingestGraphqlUsers: a changed bio is treated as a cache update", () => {
+  const handle = uniqueHandle("bio");
+  assert.equal(ingestGraphqlUsers([{ handle, userId: "777", bio: "first" }]), true);
+  assert.equal(ingestGraphqlUsers([{ handle, userId: "777", bio: "second" }]), true);
+});
+
+test("ingestGraphqlUsers: viewer-relationship flags propagate", () => {
+  const handle = uniqueHandle("viewer");
+  // Initial ingest without viewer flag.
+  assert.equal(ingestGraphqlUsers([{ handle, userId: "999" }]), true);
+  // Flipping viewerFollowing -> true must be detected as a change.
+  assert.equal(ingestGraphqlUsers([{ handle, userId: "999", viewerFollowing: true }]), true);
+  // Same payload again → no change.
+  assert.equal(ingestGraphqlUsers([{ handle, userId: "999", viewerFollowing: true }]), false);
+});
+
+test("ingestGraphqlUsers: empty batch is a no-op", () => {
+  assert.equal(ingestGraphqlUsers([]), false);
+});
+
+test("ingestGraphqlUsers: createdAt is parsed into accountAgeDays internally without throwing", () => {
+  const handle = uniqueHandle("created");
+  // Valid X-style createdAt.
+  assert.equal(
+    ingestGraphqlUsers([{ handle, userId: "1010", createdAt: "Tue Jun 02 20:12:29 +0000 2009" }]),
+    true,
+  );
+  // Garbage createdAt must not throw — it is just dropped.
+  const handle2 = uniqueHandle("createdbad");
+  assert.doesNotThrow(() =>
+    ingestGraphqlUsers([{ handle: handle2, userId: "2020", createdAt: "not a date" }]),
+  );
+});


### PR DESCRIPTION
## 背景

v0.2 上线后两周线上跑出来三类问题：
1. **uid 解析偶尔被 X 的 avatar media id 污染**（之前 `fix: avoid avatar ids as x user ids` 是临时补丁，没治根）
2. **没有针对 viewer-self / 已关注 / 已 mute 的过滤**，扩展会去给你自己 follow 的 KOL 上 spam 报告
3. **公榜命中需要每个号手动点拉黑**，活跃用户希望自动化

本 PR 一并解决，附带 UI 升级 + 一处 XSS 防御补丁。

## 本次改动

### 1. 身份解析硬化

服务于一个目标：**只要把账号的真 `rest_id` 抓到了就 always 抓对**。

- **NEW**: `extension/entrypoints/x-graphql-main.content.ts` — MAIN-world `document_start` 脚本，monkey-patch `window.fetch` 和 `XMLHttpRequest`，拦截 X 自家 `/i/api/graphql/*` 响应。深度遍历 JSON 找 `__typename === 'User'`，`rest_id ≠ id_str` 直接丢弃。CustomEvent `mxga:x-users` 跨 world 投递到 ISOLATED-world。
- **NEW**: JSON-LD parser 读 `<script type="application/ld+json">` 的 `mainEntity.identifier` — X 自己宣告的规范 ID。
- **NEW**: Action-button 兜底 — 从 `data-testid="<uid>-(follow|unfollow|subscribe)"` 拿 uid。
- **HARDENED**: `fiberUserId` 交叉校验 `legacy.id_str` vs `rest_id`；用 Twitter snowflake epoch 反解 candidate uid 的注册时间，跟 `legacy.created_at` 比对，差异 >2 天且 uid 撞 avatar media id → 直接丢弃 + `console.warn` 留痕。
- **NEW**: `extension/lib/graphql-users.ts` 共享 ingest 缓存模块。
- **NEW**: `test/uid-detection.test.ts` 9 条 `ingestGraphqlUsers` 公开 API 回归。

Profile 页 uid 优先级：`jsonLd > action-button > graphql > fiber > banner-url`。

### 2. Viewer-scoped 过滤

5 个新 Signal 字段（`viewerIsSelf / viewerFollowing / viewerBlocking / viewerMuting / viewerFollowRequestSent`）。前端 `process()` step 0 短路；服务端 `/v1/classify` + `/v1/report` 也短路，返回 `{ ignored: true, status: 'viewer_ignored' }`，不写 D1。

效果：你自己、你 follow 的人、你 mute / block 的人，**永远不会被自己上报**，公榜信任分不会被自己污染。

### 3. 公榜命中自动拉黑（默认 OFF）

新设置 `autoBlockListHits`。开启后两条路径都进入既有的限速拉黑队列：

| 来源 | 触发条件 | 备注 |
|---|---|---|
| `list_hit` | `/v1/check` 命中（无视 verdict.label） | 服务端已经过滤 `status='human_confirmed'`，被返回就是公榜确认。管理员手动加黑名单（即使 AI 标签是 "不确定 35%"）也会自动拉。**这一条修复了 Mary @Mary1463962 / Mark @Mark76056378472 的线上 case。** |
| `cache_hit` | 本地缓存 verdict 是 spammy 标签 | 缓存是本机 AI 判断，软信号，只在 spam / porn_bot / likely_spam 时下手 |

两条 auto-block 路径都**跳过 `confirm_spam` 上报**（不污染公榜 reporter count）。手动拉黑保留 confirm_spam 信号。

管理面板审计标签：`公榜命中` / `缓存命中` / `手动` / `一键全部`。

### 4. UI 重写 + XSS 加固

- **浅色主题**：`@media (prefers-color-scheme: light)` 跟系统切换
- **每行勾选**：bubble card 内每条 finding 带 checkbox，一键拉黑只针对选中
- **异步上报状态机**：上报 → 上报中 → 已上报 / 失败（带错误 tooltip）
- **Popover 边界 flip**：超出 viewport 自动翻转到另一侧
- **雷达环进度**：pill 用 conic-gradient 可视化扫描进度
- **`escHtml()` 加固**：ui.ts 所有 `innerHTML` 模板插值统一转义。**关闭一条真实存在的 prompt-injection 路径**——攻击者 bio 注入 → LLM `reasons` 字段输出 HTML → 角标悬浮卡 `innerHTML` → content-script 上下文 RCE。Shadow DOM **不**隔离 JS 执行。

### 5. 其他

- 管理面板左上角图标：通用盾牌 SVG → 小蓝吉祥物 PNG（跟 popup 一致）
- `mountBadge` / `mountStatus` 宿主节点加 5 条 inline style 防 X flex 容器压缩
- `canReport` 登录态变化触发重扫，让已挂载的 ghost badge 立刻获得上报按钮
- 版本 `0.2.0 → 0.3.0`
- README + docs/STATUS.md 同步更新

## 测试验证

| 检查 | 结果 |
|---|---|
| Extension TypeScript (strict + noUncheckedIndexedAccess) | ✅ EXIT=0 |
| Edge Worker TypeScript | ✅ EXIT=0 |
| Biome（24 文件） | ✅ 0 errors |
| 测试套件 | ✅ 15/15 通过（其中 9 条是这次新加的 uid-detection 回归） |
| WXT 生产构建 | ✅ chrome-mv3 388.73 kB |
| Manifest 校验 | ✅ `world: MAIN` + `run_at: document_start` 正确登记，dev-only host_permissions 未泄漏 |

真机：在 luolei 自测账号上验证了 Mary / Mark 两个 admin-blacklisted-uncertain 号会被自动拉黑（这是开发期出现并修复的两个 bug 的最终 ground-truth case）。

## 风险与回滚

**风险面**：
- MAIN-world fetch 拦截理论上能影响 X 自家 API 行为。已做：只读 clone() + 失败 .catch() 吞掉，不阻断响应链。已实测无报错。
- nativeBlock 走 X 自家菜单 UI，X 改版后选择器可能失效（这是 v0.2 既有风险，未变）。
- 公榜自动拉黑默认 OFF，新用户体感无变化。

**回滚**：squash merge 后单 commit 可 `git revert`。Chrome Web Store 发版后如发现严重问题，从 v0.2.0 zip 走 hotfix 通道。

## 关联 Issue

LUO-15 主线（Multica Epic 「Make X Great Again 项目主线」），无独立子 issue。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)