### PR TITLE
修复：允许“分析”状态显示手动处理浮层，并在手动操作后取消进行中的分析请求

### DIFF
--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -22,6 +22,17 @@ async function call(path: string, init?: RequestInit): Promise<Record<string, un
   return body as Record<string, unknown>;
 }
 
+async function callCancelable(
+  path: string,
+  init?: RequestInit,
+  signal?: AbortSignal,
+): Promise<Record<string, unknown>> {
+  const res = await fetch((await base()) + path, { ...init, signal });
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`);
+  return body as Record<string, unknown>;
+}
+
 /** POST JSON, attaching the GitHub token when present (gates write endpoints). */
 async function authedPost(signals: unknown) {
   const tok = await getGhToken();
@@ -89,6 +100,8 @@ async function ghPoll(deviceCode: string) {
 }
 
 export default defineBackground(() => {
+  const classifyControllers = new Map<string, AbortController>();
+
   chrome.runtime.onMessage.addListener(
     (msg: BgRequest, _s: chrome.runtime.MessageSender, sendResponse: (r: BgResponse) => void) => {
       (async () => {
@@ -130,24 +143,46 @@ export default defineBackground(() => {
             if (hitCount) void bumpStatBy("hitPublic", hitCount);
             sendResponse({ ok: true, data: { hits } });
           } else if (msg.type === "classify") {
-            const r = await call("/v1/classify", await authedPost(msg.signals));
-            const rec = r.record as { verdict: CurationRecord["verdict"]; status: string };
-            const s = msg.signals as { userId?: string; handle: string };
-            // Only count fresh LLM work, not cache returns (server tells us via `cached`).
-            if (!r.cached) void bumpStat("scanned");
-            sendResponse({
-              ok: true,
-              data: {
-                record: {
-                  userId: s.userId ?? "",
-                  handle: s.handle,
-                  verdict: rec.verdict,
-                  reviewStatus: rec.status,
-                  model: "edge",
-                } satisfies CurationRecord,
-                idResolved: !!s.userId,
-              },
-            });
+            const controller = new AbortController();
+            classifyControllers.set(msg.requestId, controller);
+            try {
+              const r = await callCancelable(
+                "/v1/classify",
+                await authedPost(msg.signals),
+                controller.signal,
+              );
+              const rec = r.record as { verdict: CurationRecord["verdict"]; status: string };
+              const s = msg.signals as { userId?: string; handle: string };
+              // Only count fresh LLM work, not cache returns (server tells us via `cached`).
+              if (!r.cached) void bumpStat("scanned");
+              sendResponse({
+                ok: true,
+                data: {
+                  record: {
+                    userId: s.userId ?? "",
+                    handle: s.handle,
+                    verdict: rec.verdict,
+                    reviewStatus: rec.status,
+                    model: "edge",
+                  } satisfies CurationRecord,
+                  idResolved: !!s.userId,
+                },
+              });
+            } catch (e) {
+              if (controller.signal.aborted) {
+                sendResponse({ ok: false, error: "classify_canceled" });
+              } else {
+                throw e;
+              }
+            } finally {
+              if (classifyControllers.get(msg.requestId) === controller) {
+                classifyControllers.delete(msg.requestId);
+              }
+            }
+          } else if (msg.type === "cancel_classify") {
+            classifyControllers.get(msg.requestId)?.abort();
+            classifyControllers.delete(msg.requestId);
+            sendResponse({ ok: true, data: { canceled: true } });
           } else if (msg.type === "confirm_spam") {
             await call("/v1/confirm", await authedPost(msg.signals));
             void bumpStat("blocked");

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -270,7 +270,11 @@ function clearMounts(anchor: HTMLElement) {
 
 /** Lightweight "queued" marker — NOT a final mount, so scan() revisits it
  *  once the token bucket refills (newly loaded comments never get stuck). */
-function mountStatus(anchor: HTMLElement, kind: "analyzing" | "pending" | "blocking") {
+function mountStatus(
+  anchor: HTMLElement,
+  kind: "analyzing" | "pending" | "blocking",
+  actions?: Parameters<typeof createStatusBadge>[1],
+) {
   const cls = kind === "pending" ? "xss-pending" : "xss-mount";
   if (anchor.querySelector(`:scope > .${cls}`)) return;
   const host = document.createElement("span");
@@ -284,7 +288,7 @@ function mountStatus(anchor: HTMLElement, kind: "analyzing" | "pending" | "block
   const sr = host.attachShadow({ mode: "open" });
   const st = document.createElement("style");
   st.textContent = STYLE;
-  sr.append(st, createStatusBadge(kind));
+  sr.append(st, createStatusBadge(kind, actions));
   anchor.appendChild(host);
 }
 const mountPending = (a: HTMLElement) => mountStatus(a, "pending");
@@ -300,7 +304,8 @@ export default defineContentScript({
     let bubbleApi: ReturnType<typeof createBubble> | null = null;
     let dismissed = false;
     let canReport = false;
-    const inflight = new Map<string, Promise<void>>(); // L0 in-flight de-dup
+    type InflightClassify = { promise: Promise<void>; requestId: string; canceled: boolean };
+    const inflight = new Map<string, InflightClassify>(); // L0 in-flight de-dup
     const anchorByKey = new Map<string, HTMLElement>();
     const nodeKey = new WeakMap<HTMLElement, string>(); // virtualization-safe
     const findings: Finding[] = [];
@@ -507,6 +512,7 @@ export default defineContentScript({
     }
 
     async function blockAccount(key: string, sig: Signals): Promise<boolean> {
+      cancelClassify(key);
       const active = findFinding(sig);
       if (active) {
         active.blockQueued = false;
@@ -685,7 +691,15 @@ export default defineContentScript({
         if (!dismissed) bubbleApi?.update(findings);
       }
     }
-    async function reportAccount(sig: Signals) {
+    function cancelClassify(key: string) {
+      const running = inflight.get(key);
+      if (!running || running.canceled) return;
+      running.canceled = true;
+      void send({ type: "cancel_classify", requestId: running.requestId });
+    }
+
+    async function reportAccount(key: string, sig: Signals) {
+      cancelClassify(key);
       const resp = await send({ type: "report_spam", signals: sig });
       if (!resp.ok) throw new Error(resp.error || "上报失败");
     }
@@ -737,6 +751,17 @@ export default defineContentScript({
       mountBlocking(anchor); // the cell collapses once finalizeBlocked runs
       return true;
     }
+    function badgeActions(anchor: HTMLElement, key: string, sig: Signals) {
+      return {
+        onBlock: () => void blockAccount(key, sig),
+        onHide: () => hideTweet(anchor),
+        onReport: () => reportAccount(key, sig),
+        onAppeal: () => window.open(APPEAL_URL, "_blank", "noopener"),
+        onCheck: () => void classify(anchor, key, sig),
+        canReport,
+      };
+    }
+
     function badgeFor(
       anchor: HTMLElement,
       key: string,
@@ -747,21 +772,7 @@ export default defineContentScript({
     ) {
       tallyScan(key);
       clearMounts(anchor);
-      mountBadge(anchor, () =>
-        createBadge(
-          v,
-          {
-            onBlock: () => void blockAccount(key, sig),
-            onHide: () => hideTweet(anchor),
-            onReport: () => reportAccount(sig),
-            onAppeal: () => window.open(APPEAL_URL, "_blank", "noopener"),
-            onCheck: () => void classify(anchor, key, sig),
-            canReport,
-          },
-          note,
-          source,
-        ),
-      );
+      mountBadge(anchor, () => createBadge(v, badgeActions(anchor, key, sig), note, source));
     }
 
     function renderCached(anchor: HTMLElement, key: string, sig: Signals, c: Cached) {
@@ -771,15 +782,24 @@ export default defineContentScript({
 
     async function classify(anchor: HTMLElement, key: string, sig: Signals) {
       const running = inflight.get(key);
-      if (running) return running;
-      mountStatus(anchor, "analyzing"); // animated shimmer while AI works
+      if (running) return running.promise;
+      mountStatus(anchor, "analyzing", badgeActions(anchor, key, sig)); // animated shimmer while AI works
+      const requestId = crypto.randomUUID();
+      const state: InflightClassify = {
+        requestId,
+        canceled: false,
+        promise: Promise.resolve(),
+      };
       const p = (async () => {
         const { isProfile: _p, ...rest } = sig;
         const resp = await send<{ record: CurationRecord; idResolved: boolean }>({
           type: "classify",
+          requestId,
           signals: rest,
         });
-        if (!resp.ok || !resp.data) return;
+        if (state.canceled || !resp.ok || !resp.data) return;
+        const current = inflight.get(key);
+        if (!current || current.requestId !== requestId || current.canceled) return;
         const { record, idResolved } = resp.data;
         badgeFor(anchor, key, sig, record.verdict, idResolved ? undefined : "数字ID未解析，handle 兜底", "fresh");
         pushFinding(sig, record.verdict);
@@ -794,11 +814,13 @@ export default defineContentScript({
           ...(sig.avatarUrl ? { avatarUrl: sig.avatarUrl } : {}),
         });
       })();
-      inflight.set(key, p);
+      state.promise = p;
+      inflight.set(key, state);
       try {
         await p;
       } finally {
-        inflight.delete(key);
+        const current = inflight.get(key);
+        if (current?.requestId === requestId) inflight.delete(key);
       }
     }
 

--- a/extension/lib/types.ts
+++ b/extension/lib/types.ts
@@ -45,7 +45,8 @@ export type BgRequest =
   | { type: "whitelist_refresh" }
   | { type: "lookup"; userId: string }
   | { type: "lookup_batch"; userIds: string[] }
-  | { type: "classify"; signals: Omit<Signals, "isProfile"> }
+  | { type: "classify"; requestId: string; signals: Omit<Signals, "isProfile"> }
+  | { type: "cancel_classify"; requestId: string }
   | { type: "report_spam"; signals: Omit<Signals, "isProfile"> }
   | { type: "confirm_spam"; signals: Omit<Signals, "isProfile"> }
   | { type: "gh_start" }

--- a/extension/lib/ui.ts
+++ b/extension/lib/ui.ts
@@ -1080,6 +1080,11 @@ export interface BadgeActions {
   canReport?: boolean;
 }
 
+interface ManualPopoverOptions {
+  hideCheck?: boolean;
+  description?: string;
+}
+
 /** Inline pill on the author row; hover/focus → popover with reasons. */
 /** Where a verdict came from. Drives badge color + tag so the user can tell
  *  「公榜确认 / 本地缓存 / AI 现场判定 / 维护者白名单」apart at a glance.
@@ -1160,13 +1165,96 @@ async function runReportButton(btn: HTMLButtonElement, action: () => void | Prom
   }
 }
 
+function attachManualPopover(
+  el: HTMLElement,
+  a: BadgeActions,
+  opts: ManualPopoverOptions = {},
+): void {
+  const hideCheck = !!opts.hideCheck;
+  if (!a.canReport) {
+    if (!hideCheck) el.addEventListener("click", () => a.onCheck?.());
+    return;
+  }
+  el.tabIndex = 0;
+  let manualPop: HTMLElement | null = null;
+  let manualHideTimer: number | undefined;
+  const hideManual = () => {
+    if (manualHideTimer) window.clearTimeout(manualHideTimer);
+    manualHideTimer = undefined;
+    manualPop?.remove();
+    manualPop = null;
+  };
+  const cancelManualHide = () => {
+    if (manualHideTimer) window.clearTimeout(manualHideTimer);
+    manualHideTimer = undefined;
+  };
+  const scheduleManualHide = () => {
+    cancelManualHide();
+    manualHideTimer = window.setTimeout(hideManual, 180);
+  };
+  const showManual = (ev?: Event) => {
+    cancelManualHide();
+    if (!manualPop) {
+      manualPop = document.createElement("div");
+      manualPop.className = "xss pop card";
+      manualPop.style.display = "block";
+      manualPop.innerHTML = `
+        <h4>手动处理</h4>
+        <div style="color:var(--muted);line-height:1.55">${escHtml(
+          opts.description ??
+            (hideCheck
+              ? "AI 正在分析中；如已确认可疑，可直接上报或拉黑并上报。"
+              : "未命中公榜时，可主动检查；确认可疑后再上报或拉黑并上报。"),
+        )}</div>
+        <div class="acts">
+          ${hideCheck ? "" : '<button data-c>检查</button>'}
+          <button data-r>上报</button>
+          <button data-b>拉黑并上报</button>
+        </div>`;
+      if (!hideCheck) {
+        manualPop.querySelector("[data-c]")?.addEventListener("click", () => {
+          a.onCheck?.();
+          hideManual();
+        });
+      }
+      manualPop.querySelector<HTMLButtonElement>("[data-r]")?.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        const btn = ev.currentTarget as HTMLButtonElement;
+        void runReportButton(btn, a.onReport).then(() => {
+          if (btn.classList.contains("done")) window.setTimeout(hideManual, 600);
+        });
+      });
+      manualPop.querySelector("[data-b]")?.addEventListener("click", () => {
+        a.onBlock();
+        hideManual();
+      });
+      manualPop.addEventListener("mouseenter", cancelManualHide);
+      manualPop.addEventListener("mouseleave", scheduleManualHide);
+      getPopoverRoot().appendChild(manualPop);
+    }
+    placePopover(manualPop, popPoint(ev, el));
+  };
+  el.addEventListener("click", showManual);
+  el.addEventListener("mouseenter", showManual);
+  el.addEventListener("focus", showManual);
+  el.addEventListener("mouseleave", scheduleManualHide);
+  el.addEventListener("blur", scheduleManualHide);
+}
+
 /** Animated transient states for newly-found and queued accounts. */
-export function createStatusBadge(kind: "analyzing" | "pending" | "blocking"): HTMLElement {
+export function createStatusBadge(
+  kind: "analyzing" | "pending" | "blocking",
+  a?: BadgeActions,
+): HTMLElement {
   const el = document.createElement("span");
   if (kind === "analyzing") {
     el.className = "xss-badge analyzing labeled";
-    el.setAttribute("aria-label", "MXGA 正在分析");
+    el.setAttribute(
+      "aria-label",
+      a?.canReport ? "MXGA 正在分析，可手动上报或拉黑并上报" : "MXGA 正在分析",
+    );
     el.innerHTML = `<span class="xss-ico">${icon("shield", "currentColor", 12)}</span><span class="xss-label">分析</span>`;
+    if (a) attachManualPopover(el, a, { hideCheck: true });
   } else if (kind === "pending") {
     el.className = "xss-badge pending labeled";
     el.setAttribute("aria-label", "MXGA 排队检测");
@@ -1200,66 +1288,7 @@ export function createBadge(
     el.className = "xss-badge ghost labeled";
     el.setAttribute("aria-label", a.canReport ? "MXGA：检查、上报或拉黑并上报" : "MXGA 手动检查");
     el.innerHTML = `<span class="xss-ico">${icon("shield", "currentColor", 12)}</span><span class="xss-label">检查</span>`;
-    if (!a.canReport) {
-      el.addEventListener("click", () => a.onCheck?.());
-      return el;
-    }
-    let manualPop: HTMLElement | null = null;
-    let manualHideTimer: number | undefined;
-    const hideManual = () => {
-      if (manualHideTimer) window.clearTimeout(manualHideTimer);
-      manualHideTimer = undefined;
-      manualPop?.remove();
-      manualPop = null;
-    };
-    const cancelManualHide = () => {
-      if (manualHideTimer) window.clearTimeout(manualHideTimer);
-      manualHideTimer = undefined;
-    };
-    const scheduleManualHide = () => {
-      cancelManualHide();
-      manualHideTimer = window.setTimeout(hideManual, 180);
-    };
-    const showManual = (ev?: Event) => {
-      cancelManualHide();
-      if (!manualPop) {
-        manualPop = document.createElement("div");
-        manualPop.className = "xss pop card";
-        manualPop.style.display = "block";
-        manualPop.innerHTML = `
-          <h4>手动处理</h4>
-          <div style="color:var(--muted);line-height:1.55">未命中公榜时，可主动检查；确认可疑后再上报或拉黑并上报。</div>
-          <div class="acts">
-            <button data-c>检查</button>
-            <button data-r>上报</button>
-            <button data-b>拉黑并上报</button>
-          </div>`;
-        manualPop.querySelector("[data-c]")?.addEventListener("click", () => {
-          a.onCheck?.();
-          hideManual();
-        });
-        manualPop.querySelector<HTMLButtonElement>("[data-r]")?.addEventListener("click", (ev) => {
-          ev.stopPropagation();
-          const btn = ev.currentTarget as HTMLButtonElement;
-          void runReportButton(btn, a.onReport).then(() => {
-            if (btn.classList.contains("done")) window.setTimeout(hideManual, 600);
-          });
-        });
-        manualPop.querySelector("[data-b]")?.addEventListener("click", () => {
-          a.onBlock();
-          hideManual();
-        });
-        manualPop.addEventListener("mouseenter", cancelManualHide);
-        manualPop.addEventListener("mouseleave", scheduleManualHide);
-        getPopoverRoot().appendChild(manualPop);
-      }
-      placePopover(manualPop, popPoint(ev, el));
-    };
-    el.addEventListener("click", showManual);
-    el.addEventListener("mouseenter", showManual);
-    el.addEventListener("focus", showManual);
-    el.addEventListener("mouseleave", scheduleManualHide);
-    el.addEventListener("blur", scheduleManualHide);
+    attachManualPopover(el, a);
     return el;
   }
   const meta = LABEL[v.label];


### PR DESCRIPTION
## 变更原因
当前扩展在账号状态显示为 `分析` 时，渲染的是一个纯展示用的状态 badge，不会复用 `检查` 状态下已有的「手动处理」popover 逻辑。

这会导致一个交互问题：
- 用户在 AI 仍在分析时，无法直接执行手动处理；
- 即使用户已经明确判断该账号可疑，也不能立刻点击 `上报` 或 `拉黑并上报`；
- 如果用户手动操作与后台 `classify` 请求同时发生，还可能被迟到的分析结果覆盖当前 UI。

因此，这个 PR 的目标是让 `分析` 状态也支持手动处理，并且避免手动操作后被过期的分析结果反向覆盖。

## 变更内容
- 让 `分析` 状态复用现有的「手动处理」popover；
- 在 `分析` 状态下隐藏 `检查` 按钮，仅保留：
  - `上报`
  - `拉黑并上报`
- 为 `classify` 请求增加 `requestId`；
- 在 background 中为进行中的 `classify` 请求建立 `AbortController`；
- 当用户在 `分析` 状态点击 `上报` 或 `拉黑并上报` 时：
  - 立即取消对应的进行中 `classify` 请求；
  - 若取消与返回结果发生竞争，也会在 content 侧忽略过期结果；
- 保留原有的 `inflight` 去重逻辑，避免重复触发分析请求。

## 影响范围
- `extension/lib/ui.ts`
- `extension/entrypoints/content.ts`
- `extension/entrypoints/background.ts`
- `extension/lib/types.ts`

## 验证
已本地执行：
- `npm --prefix extension run compile`
- `git diff --check`

重点验证场景：
- `分析` 状态 hover/click 后可弹出「手动处理」popover；
- `分析` 状态下不显示 `检查`，仅显示 `上报` / `拉黑并上报`；
- 点击 `上报` 或 `拉黑并上报` 后，会取消对应的进行中分析请求；
- 迟到的 `classify` 返回不会再覆盖手动操作后的 UI。
