### PR TITLE
fix(admin): repair broken GOVERNANCE.md link

### DIFF
--- a/services/edge/src/pages/admin.ts
+++ b/services/edge/src/pages/admin.ts
@@ -688,7 +688,7 @@ const SCRIPT = String.raw`
     $('app').innerHTML=
       '<div class="bar">'
       +'<div><h1>'+ ${JSON.stringify(LOGO_SVG)} +'<span>'+ ${JSON.stringify(BRAND.acronym)} +' · 审核台 · 守门员</span></h1>'
-      +'<div class="sub">守门员才能进 · <b style="color:var(--danger)">拉黑</b>=进公榜 · <b style="color:var(--ok)">白名单</b>=永不扫 · 驳回/移除=不公开 · 规则见 <a href="'+GH+'/blob/main/docs/GOVERNANCE.md" target="_blank">GOVERNANCE</a></div></div>'
+      +'<div class="sub">守门员才能进 · <b style="color:var(--danger)">拉黑</b>=进公榜 · <b style="color:var(--ok)">白名单</b>=永不扫 · 驳回/移除=不公开 · 规则见 <a href="${BRAND.governance}" target="_blank">GOVERNANCE</a></div></div>'
       +'<div class="right"><span class="ok">已认证</span><button class="btn sm" onclick="window.__xss.logout()">退出</button>'+themeBtnHtml()+'</div>'
       +'</div>'
       +'<div class="tabs">'


### PR DESCRIPTION
Follow-up to #30, which fixed the same broken `docs/GOVERNANCE.md` 404 in both `brand.ts` files but missed a third occurrence.

## 改动
- **`services/edge/src/pages/admin.ts`**: 审核台页脚的 GOVERNANCE 链接仍指向 `docs/GOVERNANCE.md`（404，实际文件在仓库根目录）。改为直接复用 `BRAND.governance`（#30 已修正的常量），使路径单一来源、不再漂移。

## 验证
- `tsc --noEmit` ✅
- 仓库内已无其他 `docs/GOVERNANCE.md` 引用

🤖 Generated with [Claude Code](https://claude.com/claude-code)