### PR TITLE
feat(extension): 默认账号处理动作改为静音

### DIFF
--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -1,5 +1,6 @@
 import { isBlockedSync, warm as warmBlocklist, addBlocked } from "../lib/blocklist";
 import { BRAND } from "../lib/brand";
+import { actionApiPath, type ModerationAction } from "../lib/moderation-action";
 import { onSettingsChange, getSettings } from "../lib/settings";
 import { addBlockRecord, bumpStats } from "../lib/store";
 import { type Cached, cacheGet, cacheSet, signalsHash } from "../lib/cache";
@@ -45,8 +46,8 @@ const FALLBACK_X_BEARER =
   "Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA";
 const ct0 = () => (document.cookie.match(/ct0=([^;]+)/)?.[1] ?? "");
 
-const BLOCK_DELAY_MS = 1200;
-const BLOCK_JITTER_MS = 700;
+const ACCOUNT_ACTION_DELAY_MS = 1200;
+const ACCOUNT_ACTION_JITTER_MS = 700;
 const BLOCK_SUCCESS_SETTLE_MS = 180;
 const BLOCK_SHORT_COOLDOWN_EVERY = 45;
 const BLOCK_SHORT_COOLDOWN_MS = 8_000;
@@ -63,7 +64,7 @@ interface BlockRound {
   cooldownUntil: number;
 }
 
-interface BlockAttempt {
+interface AccountActionAttempt {
   ok: boolean;
   status?: number;
   retryable?: boolean;
@@ -149,7 +150,7 @@ function recordBlockBackoff(ms: number) {
   });
 }
 
-function recordBlockFailure(attempt: BlockAttempt) {
+function recordBlockFailure(attempt: AccountActionAttempt) {
   if (attempt.status === 429) {
     recordBlockBackoff(attempt.retryAfterMs ?? BLOCK_RATE_LIMIT_COOLDOWN_MS);
   } else if (attempt.retryable) {
@@ -157,7 +158,7 @@ function recordBlockFailure(attempt: BlockAttempt) {
   }
 }
 
-function retryDelayForAttempt(attempt: BlockAttempt, tries: number) {
+function retryDelayForAttempt(attempt: AccountActionAttempt, tries: number) {
   if (!attempt.retryable) return 0;
   if (attempt.status === 429) {
     return Math.min(60_000, attempt.retryAfterMs ?? BLOCK_RATE_LIMIT_COOLDOWN_MS);
@@ -175,8 +176,8 @@ async function waitForBlockSlot() {
     }
 
     const lastAt = storageNumber(LS_LAST_BLOCK);
-    const jitter = Math.floor(Math.random() * BLOCK_JITTER_MS);
-    const remaining = lastAt + BLOCK_DELAY_MS + jitter - Date.now();
+    const jitter = Math.floor(Math.random() * ACCOUNT_ACTION_JITTER_MS);
+    const remaining = lastAt + ACCOUNT_ACTION_DELAY_MS + jitter - Date.now();
     if (remaining <= 0) break;
     await sleep(Math.min(1000, remaining));
   }
@@ -198,8 +199,12 @@ async function withBlockLock<T>(fn: () => Promise<T>): Promise<T> {
   return locks ? locks.request(BLOCK_LOCK_NAME, fn) : fn();
 }
 
-/** Silent X block via the first-party blocks/create endpoint. */
-async function apiBlock(userId?: string, handle?: string): Promise<BlockAttempt> {
+/** Silent X account action via the first-party mute/block endpoints. */
+async function apiAccountAction(
+  action: ModerationAction,
+  userId?: string,
+  handle?: string,
+): Promise<AccountActionAttempt> {
   try {
     const csrf = ct0();
     if (!csrf) return { ok: false, retryable: false };
@@ -210,7 +215,7 @@ async function apiBlock(userId?: string, handle?: string): Promise<BlockAttempt>
     else return { ok: false, retryable: false };
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 15_000);
-    const res = await fetch(`${blockApiOrigin()}/i/api/1.1/blocks/create.json`, {
+    const res = await fetch(`${blockApiOrigin()}${actionApiPath(action)}`, {
       method: "POST",
       credentials: "include",
       signal: controller.signal,
@@ -235,10 +240,14 @@ async function apiBlock(userId?: string, handle?: string): Promise<BlockAttempt>
   }
 }
 
-async function coordinatedApiBlock(userId?: string, handle?: string): Promise<BlockAttempt> {
+async function coordinatedAccountAction(
+  action: ModerationAction,
+  userId?: string,
+  handle?: string,
+): Promise<AccountActionAttempt> {
   return withBlockLock(async () => {
     await waitForBlockSlot();
-    const attempt = await apiBlock(userId, handle);
+    const attempt = await apiAccountAction(action, userId, handle);
     if (attempt.ok) recordBlockSuccess();
     else recordBlockFailure(attempt);
     return attempt;
@@ -292,9 +301,9 @@ function mountStatus(
   anchor.appendChild(host);
 }
 const mountPending = (a: HTMLElement) => mountStatus(a, "pending");
-function mountBlocking(anchor: HTMLElement) {
+function mountBlocking(anchor: HTMLElement, actions?: Parameters<typeof createStatusBadge>[1]) {
   clearMounts(anchor);
-  mountStatus(anchor, "blocking");
+  mountStatus(anchor, "blocking", actions);
 }
 
 export default defineContentScript({
@@ -460,16 +469,16 @@ export default defineContentScript({
       return finding;
     }
 
-    /** Returns true only if the account was really blocked on X. */
-    // Keep this path silent: call X's own blocks/create endpoint with the
-    // user's first-party session and the page's csrf/auth headers, then pace
-    // requests globally so bulk cleanup does not stack native confirmation
-    // sheets or hammer the endpoint from multiple X tabs.
-    async function tryRealBlock(sig: Signals): Promise<BlockAttempt> {
-      return coordinatedApiBlock(sig.userId, sig.handle);
+    /** Returns true only if the account action really completed on X. */
+    // Keep this path silent: call X's own account mute/block endpoint with
+    // the user's first-party session and the page's csrf/auth headers, then
+    // pace requests globally so bulk cleanup does not hammer X from multiple
+    // tabs. "Mute" here is X account mute: hide this user's posts.
+    async function tryAccountAction(sig: Signals): Promise<AccountActionAttempt> {
+      return coordinatedAccountAction(settings.moderationAction, sig.userId, sig.handle);
     }
 
-    async function finalizeBlocked(
+    async function finalizeAccountAction(
       key: string,
       sig: Signals,
       source: QSource = "manual",
@@ -488,7 +497,7 @@ export default defineContentScript({
       });
       await bumpStats({ blocks: 1 });
       hideTweet(anchorByKey.get(key) ?? null);
-      // Skip the confirm_spam re-report on auto-block paths:
+      // Skip the confirm_spam re-report on auto paths:
       //  - "list_hit"  : account is already publicly confirmed (that's how
       //    we got here); another confirm adds no evidence.
       //  - "cache_hit" : the user did not just take an explicit per-account
@@ -497,8 +506,9 @@ export default defineContentScript({
       //    DB (otherwise toggling auto-block would inflate reporter counts
       //    based on stale local cache).
       // Manual blocks DO send confirm_spam — that's the user's explicit
-      // per-account "yes, this is spam" signal.
-      if (source === "manual") {
+      // per-account "yes, this is spam" signal. Manual mutes stay local-only:
+      // account mute is a softer private hide action, not public curation.
+      if (source === "manual" && settings.moderationAction === "block") {
         void send({ type: "confirm_spam", signals: sig });
       }
       if (f) {
@@ -511,7 +521,7 @@ export default defineContentScript({
       if (!dismissed) bubbleApi?.update(findings);
     }
 
-    async function blockAccount(key: string, sig: Signals): Promise<boolean> {
+    async function runAccountAction(key: string, sig: Signals): Promise<boolean> {
       cancelClassify(key);
       const active = findFinding(sig);
       if (active) {
@@ -521,9 +531,9 @@ export default defineContentScript({
         active.blockSource = "manual";
         if (!dismissed) bubbleApi?.update(findings);
       }
-      const attempt = await tryRealBlock(sig);
+      const attempt = await tryAccountAction(sig);
       if (attempt.ok) {
-        await finalizeBlocked(key, sig);
+        await finalizeAccountAction(key, sig);
         return true;
       }
       const f0 = findFinding(sig);
@@ -567,11 +577,11 @@ export default defineContentScript({
           activeFinding.blockFailed = false;
           if (!dismissed) bubbleApi?.update(findings);
         }
-        const attempt = await tryRealBlock(it.sig).catch(
-          (): BlockAttempt => ({ ok: false, retryable: true }),
+        const attempt = await tryAccountAction(it.sig).catch(
+          (): AccountActionAttempt => ({ ok: false, retryable: true }),
         );
         if (attempt.ok) {
-          await finalizeBlocked(it.key, it.sig, it.source);
+          await finalizeAccountAction(it.key, it.sig, it.source);
           queue.shift();
           await persistQ();
           if (!dismissed) bubbleApi?.update(findings);
@@ -748,17 +758,18 @@ export default defineContentScript({
       autoBlockingKeys.add(key);
       tallyScan(key); // count it in the bubble's "已扫" total
       enqueueBlocks([{ key, sig, verdict }], source);
-      mountBlocking(anchor); // the cell collapses once finalizeBlocked runs
+      mountBlocking(anchor, badgeActions(anchor, key, sig)); // the cell collapses once finalizeAccountAction runs
       return true;
     }
     function badgeActions(anchor: HTMLElement, key: string, sig: Signals) {
       return {
-        onBlock: () => void blockAccount(key, sig),
+        onBlock: () => void runAccountAction(key, sig),
         onHide: () => hideTweet(anchor),
         onReport: () => reportAccount(key, sig),
         onAppeal: () => window.open(APPEAL_URL, "_blank", "noopener"),
         onCheck: () => void classify(anchor, key, sig),
         canReport,
+        action: settings.moderationAction,
       };
     }
 
@@ -849,7 +860,7 @@ export default defineContentScript({
       //     is still pending. Once drain succeeds, addBlocked() makes 0b
       //     short-circuit instead.
       if (autoBlockingKeys.has(key)) {
-        mountBlocking(anchor);
+        mountBlocking(anchor, badgeActions(anchor, key, sig));
         return;
       }
 
@@ -975,7 +986,7 @@ export default defineContentScript({
         const st = document.createElement("style");
         st.textContent = STYLE;
         container.appendChild(st);
-        const bubble = createBubble({
+      const bubble = createBubble({
           onBlockAll(fs: Finding[]) {
             // Non-blocking: enqueue all; a durable paced queue drains in the
             // background (survives reload, backs off on X's rate limit).
@@ -997,7 +1008,7 @@ export default defineContentScript({
             );
           },
           onBlockOne(f: Finding) {
-            void blockAccount(f.userId || `h:${f.handle}`, {
+            void runAccountAction(f.userId || `h:${f.handle}`, {
               isProfile: false,
               handle: f.handle,
               displayName: "",
@@ -1018,7 +1029,7 @@ export default defineContentScript({
           onDismiss() {
             dismissed = true;
           },
-        }, settings.bubblePos);
+        }, settings.bubblePos, settings.moderationAction);
         container.appendChild(bubble.el);
         if (!settings.bubble) bubble.el.style.display = "none";
         bubbleApi = bubble;

--- a/extension/entrypoints/options/App.tsx
+++ b/extension/entrypoints/options/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { clearAllLocal, getGhLogin } from "../../lib/auth";
 import { BRAND } from "../../lib/brand";
+import { type ModerationAction, actionLabels } from "../../lib/moderation-action";
 import { categorizeReason, categorizeReasons } from "../../lib/reason-category";
 import { type Settings, getSettings, setSetting } from "../../lib/settings";
 import {
@@ -301,7 +302,7 @@ function Overview() {
       <div className="mb-8 grid grid-cols-4 gap-px overflow-hidden rounded-lg border border-border bg-border">
         <Card n={s.detections} l="AI 检测总数" />
         <Card n={s.cacheHits} l="缓存命中 · 省下的 LLM 调用" />
-        <Card n={bl} l="已拉黑账号" />
+        <Card n={bl} l="已处理账号" />
         <Card n={(d.spam ?? 0) + (d.porn_bot ?? 0)} l="判定为垃圾/色情bot" />
       </div>
       <SectionH>检测类别分布</SectionH>
@@ -358,8 +359,8 @@ function Blocklist() {
   };
   return (
     <Page
-      title="拉黑记录"
-      sub={`共 ${list.length} 条 · 取消拉黑用于纠正误判（账号会重新可见）`}
+      title="处理记录"
+      sub={`共 ${list.length} 条 · 取消处理记录用于纠正误判（账号会重新可见）`}
     >
       <input
         value={q}
@@ -428,7 +429,7 @@ function Blocklist() {
                       load();
                     }}
                   >
-                    取消拉黑
+                    取消记录
                   </Btn>
                 </td>
               </tr>
@@ -436,7 +437,7 @@ function Blocklist() {
           </tbody>
         </table>
       </div>
-      {!list.length && <div className="py-10 text-center text-fg-3">还没有拉黑记录</div>}
+      {!list.length && <div className="py-10 text-center text-fg-3">还没有处理记录</div>}
     </Page>
   );
 }
@@ -540,6 +541,40 @@ function Toggle({
         {hint && <span className="block text-[12px] text-fg-3">{hint}</span>}
       </span>
     </label>
+  );
+}
+
+function ActionChoice({
+  value,
+  onChange,
+}: { value: ModerationAction; onChange: (v: ModerationAction) => void }) {
+  const choices: ModerationAction[] = ["mute", "block"];
+  return (
+    <div className="py-2">
+      <div className="mb-1 text-[13px] font-medium text-fg">默认账号处理动作</div>
+      <div className="inline-flex rounded-md border border-border-2 bg-card p-1">
+        {choices.map((choice) => {
+          const labels = actionLabels(choice);
+          const active = value === choice;
+          return (
+            <button
+              key={choice}
+              type="button"
+              onClick={() => onChange(choice)}
+              className={`rounded-sm px-3 py-1.5 text-[12px] font-semibold transition ${
+                active ? "bg-fg text-bg" : "text-fg-2 hover:bg-card-hi hover:text-fg"
+              }`}
+              title={labels.risk}
+            >
+              {choice === "mute" ? "静音用户" : "拉黑用户"}
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-1.5 text-[12px] leading-relaxed text-fg-3">
+        {actionLabels(value).description}。{actionLabels(value).risk}
+      </div>
+    </div>
   );
 }
 
@@ -711,11 +746,15 @@ function Settings() {
               label="回复区逐个自动检查"
               hint="关闭可显著降低 LLM 调用 / 更克制"
             />
+            <ActionChoice
+              value={st.moderationAction}
+              onChange={(v) => save("moderationAction", v)}
+            />
             <Toggle
               on={st.autoBlockListHits}
               onChange={(v) => save("autoBlockListHits", v)}
-              label="对已确认的垃圾号自动拉黑"
-              hint="开启后：扫到的色情/垃圾账号会被静默后台拉黑（包括公榜命中 + 本机此前判过 spam 的缓存号），不弹卡片、不需要点确认。默认关闭。"
+              label={`对已确认的垃圾号${actionLabels(st.moderationAction).automatic}`}
+              hint={`开启后：扫到的色情/垃圾账号会被静默${actionLabels(st.moderationAction).background}（包括公榜命中 + 本机此前判过 spam 的缓存号），不弹卡片、不需要点确认。默认关闭。`}
             />
           </section>
         )}
@@ -743,7 +782,7 @@ function Settings() {
         <section>
           <SectionH>数据与隐私</SectionH>
           <p className="mb-3 text-[13px] text-fg-2">
-            检测缓存、拉黑记录、统计、登录态均仅存于本机；除公开 X 数字 ID 外不存 PII。
+            检测缓存、处理记录、统计、登录态均仅存于本机；除公开 X 数字 ID 外不存 PII。
           </p>
           <div className="flex items-center gap-3">
             <Btn tier="danger" onClick={() => setClearOpen(true)}>
@@ -761,7 +800,7 @@ function Settings() {
               这会清空本机上的：
               <ul className="my-2 list-inside list-disc text-fg-3">
                 <li>AI 检测缓存（下次扫描会再调 LLM）</li>
-                <li>你的拉黑历史 + 本地处理统计</li>
+                <li>你的账号处理历史 + 本地处理统计</li>
                 <li>GitHub 登录态（仅本机，不撤 GH token）</li>
               </ul>
               <b className="text-fg">不可恢复。</b>
@@ -786,7 +825,7 @@ const About = () => (
   <Page title="关于" sub={`${BRAND.name} · 公益、开源`}>
     <div className="max-w-[680px] space-y-4 text-[13px] leading-7 text-fg-2">
       <p>
-        基于 AI 的 X(Twitter) 反垃圾 / 色情机器人扩展。被动检测、本地优先、中心服务（Cloudflare）协同；用户一键拉黑即视为人工确认信号之一。
+        基于 AI 的 X(Twitter) 反垃圾 / 色情机器人扩展。被动检测、本地优先、中心服务（Cloudflare）协同；默认一键静音用户以隐藏该用户的帖子，拉黑只作为显式高风险选项保留。
       </p>
       <div className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2">
         <div className="bg-bg p-4">
@@ -851,7 +890,7 @@ const Mascot = () => (
 
 const TABS = [
   ["overview", "概览", Overview],
-  ["blocklist", "拉黑记录", Blocklist],
+  ["blocklist", "处理记录", Blocklist],
   ["cache", "检测缓存", Cache],
   ["settings", "设置", Settings],
   ["about", "关于", About],

--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -228,8 +228,8 @@ export function App() {
       {/* Per-stat breakdown */}
       <div className="mt-2 grid grid-cols-3 gap-1.5">
         <Stat label="AI 扫描" value={stats?.scanned ?? 0} hint="新账号 LLM 判定次数" />
-        <Stat label="命中公榜" value={stats?.hitPublic ?? 0} hint="直接拉黑，零成本" accent />
-        <Stat label="亲手拉黑" value={stats?.blocked ?? 0} hint="你按的拉黑按钮" />
+        <Stat label="命中公榜" value={stats?.hitPublic ?? 0} hint="直接处理，零成本" accent />
+        <Stat label="亲手处理" value={stats?.blocked ?? 0} hint="你按的账号处理按钮" />
       </div>
 
       {whitelist && whitelist.count > 0 ? (

--- a/extension/lib/moderation-action.ts
+++ b/extension/lib/moderation-action.ts
@@ -1,0 +1,54 @@
+export type ModerationAction = "mute" | "block";
+
+export const DEFAULT_MODERATION_ACTION: ModerationAction = "mute";
+
+export interface ModerationActionLabels {
+  verb: string;
+  gerund: string;
+  done: string;
+  queued: string;
+  active: string;
+  background: string;
+  automatic: string;
+  description: string;
+  risk: string;
+}
+
+const LABELS: Record<ModerationAction, ModerationActionLabels> = {
+  mute: {
+    verb: "静音",
+    gerund: "静音中",
+    done: "已静音",
+    queued: "待静音",
+    active: "静音中",
+    background: "后台静音",
+    automatic: "自动静音",
+    description: "静音用户，隐藏该用户的帖子",
+    risk: "推荐默认：比拉黑更克制，降低 X 风控风险",
+  },
+  block: {
+    verb: "拉黑",
+    gerund: "拉黑中",
+    done: "已拉黑",
+    queued: "待拉黑",
+    active: "拉黑中",
+    background: "后台拉黑",
+    automatic: "自动拉黑",
+    description: "拉黑用户，阻止该用户与你互动",
+    risk: "高风险：短时间大量拉黑更容易触发 X 风控",
+  },
+};
+
+export function normalizeModerationAction(action: unknown): ModerationAction {
+  return action === "block" ? "block" : "mute";
+}
+
+export function actionApiPath(action: ModerationAction): string {
+  return action === "block"
+    ? "/i/api/1.1/blocks/create.json"
+    : "/i/api/1.1/mutes/users/create.json";
+}
+
+export function actionLabels(action: ModerationAction): ModerationActionLabels {
+  return LABELS[action];
+}

--- a/extension/lib/settings.ts
+++ b/extension/lib/settings.ts
@@ -1,3 +1,9 @@
+import {
+  DEFAULT_MODERATION_ACTION,
+  type ModerationAction,
+  normalizeModerationAction,
+} from "./moderation-action";
+
 // User-facing settings (chrome.storage.local, single object). Read at
 // content-script start + live-updated via storage.onChanged. No PII.
 export interface Settings {
@@ -6,15 +12,17 @@ export interface Settings {
   bubblePos: "tr" | "br"; // top-right / bottom-right
   replyAuto: boolean; // auto-check every replier in a tweet's reply section
   edgeBase: string; // advanced: override the edge service base URL
+  /** Default account action. "mute" means X account mute: hide that user's
+   *  posts from the viewer, not audio muting. "block" is available only as
+   *  an explicit high-risk choice. */
+  moderationAction: ModerationAction;
   /** When true, the corner bubble auto-expands the card view whenever a
-   *  newly-discovered spam account appears (with an explicit block action).
-   *  When false, only the pill flashes and the count goes up — the user has
-   *  to click the pill to act. Toggle is also surfaced inline inside the
-   *  card itself ("下次自动弹出"). */
+   *  newly-discovered spam account appears. When false, only the pill flashes
+   *  and the count goes up — the user has to click the pill to act. */
   autoExpandOnFinding: boolean;
   /** When true, any account the system has already concluded is spam is
-   *  silently enqueued to the paced block queue on EVERY page the user
-   *  visits — no badge, no card, no click required. Two sources count as
+   *  silently enqueued to the paced account-action queue on EVERY page the
+   *  user visits — no badge, no card, no click required. Two sources count as
    *  "system-confirmed":
    *    - step 1 cache hit  → "cache_hit"  (this device LLM-classified it
    *      as spam in a prior session and stored the verdict locally).
@@ -31,6 +39,7 @@ export const DEFAULTS: Settings = {
   bubblePos: "tr",
   replyAuto: true,
   edgeBase: "",
+  moderationAction: DEFAULT_MODERATION_ACTION,
   autoExpandOnFinding: true,
   autoBlockListHits: false,
 };
@@ -40,10 +49,18 @@ const KEY = "xss:settings";
 export async function getSettings(): Promise<Settings> {
   try {
     const g = await chrome.storage.local.get(KEY);
-    return { ...DEFAULTS, ...((g[KEY] as Partial<Settings>) ?? {}) };
+    return normalizeSettings((g[KEY] as Partial<Settings>) ?? {});
   } catch {
     return { ...DEFAULTS };
   }
+}
+
+function normalizeSettings(raw: Partial<Settings>): Settings {
+  return {
+    ...DEFAULTS,
+    ...raw,
+    moderationAction: normalizeModerationAction(raw.moderationAction),
+  };
 }
 
 export async function setSetting<K extends keyof Settings>(
@@ -65,7 +82,7 @@ export function onSettingsChange(cb: (s: Settings) => void): () => void {
     area: string,
   ) => {
     if (area === "local" && changes[KEY]) {
-      cb({ ...DEFAULTS, ...((changes[KEY].newValue as Partial<Settings>) ?? {}) });
+      cb(normalizeSettings((changes[KEY].newValue as Partial<Settings>) ?? {}));
     }
   };
   chrome.storage.onChanged.addListener(h);

--- a/extension/lib/ui.ts
+++ b/extension/lib/ui.ts
@@ -2,6 +2,7 @@
 // cannot bleed in and ours cannot leak out. Vanilla DOM — no framework
 // weight injected into the page. Tokens per docs/UX.md.
 import { BRAND } from "./brand";
+import { type ModerationAction, actionLabels } from "./moderation-action";
 import type { Label, Verdict } from "./types";
 
 export const STYLE = `
@@ -545,8 +546,8 @@ export interface Finding {
   blockQueued?: boolean;
   blockActive?: boolean;
   blockFailed?: boolean;
-  /** Set by drain() after a successful block — used by the card to strike
-   *  the row through and replace the per-row button with "已拉黑". */
+  /** Set by drain() after a successful account action — used by the card to
+   *  strike the row through and replace the per-row button with done text. */
   blocked?: boolean;
   /** Selection state for the bulk-block action. Undefined → treated as
    *  selected (the default for a fresh finding). User uncheck → false →
@@ -570,7 +571,12 @@ export interface BubbleHandlers {
 }
 
 /** Collapsed pill ⇄ expanded card. Default resting state = pill. */
-export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
+export function createBubble(
+  h: BubbleHandlers,
+  pos: "tr" | "br" = "tr",
+  action: ModerationAction = "mute",
+) {
+  const actionText = actionLabels(action);
   const root = document.createElement("div");
   root.className = `xss xss-bubble${pos === "br" ? " br" : ""}`;
   root.setAttribute("role", "status");
@@ -689,7 +695,7 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
     const total = Math.max(1, blocks.found);
     const donePct = Math.round((blocks.done / total) * 100);
     const pending = blocks.active + blocks.queued + idle;
-    return `<div class="block-progress" aria-label="拉黑进度 ${donePct}%">
+    return `<div class="block-progress" aria-label="${actionText.verb}进度 ${donePct}%">
       <div class="progress-head">
         <span>${pending > 0 ? `剩余 ${pending}` : "处理完成"}</span>
         <b>${donePct}%</b>
@@ -739,7 +745,7 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
         pill.innerHTML = progressMarkup({
           iconName: "shield-x",
           iconColor: "var(--danger)",
-          title: "拉黑中",
+          title: actionText.gerund,
           count: `${blocks.done}/${blocks.found}`,
           percent: Math.max(8, Math.round((blocks.done / Math.max(1, blocks.found)) * 100)),
           busy: true,
@@ -751,7 +757,7 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
         pill.innerHTML = progressMarkup({
           iconName: "shield-check",
           iconColor: "var(--safe)",
-          title: "已拉黑",
+          title: actionText.done,
           count: String(blocks.done),
           percent: 100,
         });
@@ -797,7 +803,7 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
           <span>${BRAND.acronym} 已启用</span>
           <span class="x" data-x>${icon("x", "currentColor", 14)}</span></div>
         <div class="sub" style="display:block;line-height:1.6">
-          正在被动检查本页账号。发现可疑的垃圾/色情机器人时，会在这里提示并提供一键处理。</div>
+          正在被动检查本页账号。发现可疑的垃圾/色情机器人时，会在这里提示并提供一键${actionText.verb}。</div>
         <div class="row"><span class="lnk" data-gov>为什么 / 治理</span></div>`;
       card.querySelector("[data-x]")?.addEventListener("click", () => collapse());
       card.querySelector("[data-gov]")?.addEventListener("click", () =>
@@ -833,20 +839,20 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
     ];
     card.innerHTML = `
 	      <div class="hd">${icon("shield-alert", "var(--brand)", 16)}
-	        <span>${actionableCount || activeCount || queuedCount ? `本页命中 ${findings.length} 个账号` : `本页已拉黑 ${doneCount} 个账号`}</span>
+	        <span>${actionableCount || activeCount || queuedCount ? `本页命中 ${findings.length} 个账号` : `本页${actionText.done} ${doneCount} 个账号`}</span>
 	        <span class="x" data-x>${icon("x", "currentColor", 14)}</span></div>
 	      <div class="sub">
 	        <span class="metric" title="色情/垃圾 ${danger}，疑似 ${warn}">
 	          <i style="background:var(--danger)"></i><b>${findings.length}</b><em>命中</em>
 	        </span>
-	        <span class="metric" title="正在后台拉黑">
+	        <span class="metric" title="正在${actionText.background}">
 	          <i style="background:var(--danger)"></i><b>${activeCount}</b><em>正在</em>
 	        </span>
-	        <span class="metric" title="等待后台拉黑">
-	          <i style="background:var(--brand)"></i><b>${queuedCount}</b><em>待拉</em>
+	        <span class="metric" title="等待${actionText.background}">
+	          <i style="background:var(--brand)"></i><b>${queuedCount}</b><em>${action === "block" ? "待拉" : "待静"}</em>
 	        </span>
-	        <span class="metric" title="${failedCount ? `失败 ${failedCount}，` : ""}已成功拉黑">
-	          <i style="background:${failedCount ? "var(--warn)" : "var(--safe)"}"></i><b>${doneCount}</b><em>已拉</em>
+	        <span class="metric" title="${failedCount ? `失败 ${failedCount}，` : ""}已成功${actionText.verb}">
+	          <i style="background:${failedCount ? "var(--warn)" : "var(--safe)"}"></i><b>${doneCount}</b><em>${action === "block" ? "已拉" : "已静"}</em>
 	        </span>
 	      </div>
       ${renderBlockProgress(blocks, idleCount)}
@@ -889,14 +895,14 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
                     ? "xss-act retry"
                   : "xss-act";
             const actText = f.blocked
-              ? "已拉黑"
+              ? actionText.done
               : f.blockActive
-                ? "拉黑中"
+                ? actionText.active
                 : f.blockQueued
-                  ? "待拉黑"
+                  ? actionText.queued
                   : f.blockFailed
                     ? "重试"
-                    : "拉黑";
+                    : actionText.verb;
             const source = f.blockSource ? ` · ${BLOCK_SOURCE_TEXT[f.blockSource]}` : "";
             return `<div class="${rowClass}">
               <input type="checkbox" class="xss-row-cb" data-sel="${id}"
@@ -907,10 +913,10 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
                 <div class="qname">${name}</div>
                 <div class="qmeta" style="color:${col}">@${escHtml(f.handle)} · ${m.zh} ${(f.verdict.confidence * 100).toFixed(0)}%</div>
                 ${snip ? `<div class="qsnip">${snip}</div>` : ""}
-                ${f.blockFailed ? `<div class="qnote" style="color:var(--warn)">自动屏蔽失败 · <a href="https://x.com/${escHtml(f.handle)}" target="_blank" rel="noopener" style="color:var(--warn)">手动屏蔽</a></div>` : ""}
-                ${f.blockActive && !f.blocked ? `<div class="qnote" style="color:var(--danger)">正在后台拉黑${source}</div>` : ""}
-                ${f.blockQueued && !f.blockActive && !f.blocked ? `<div class="qnote" style="color:var(--brand)">待后台拉黑${source}</div>` : ""}
-                ${f.blocked ? `<div class="qnote" style="color:var(--safe)">✓ 已拉黑${source}</div>` : ""}
+                ${f.blockFailed ? `<div class="qnote" style="color:var(--warn)">${actionText.automatic}失败 · <a href="https://x.com/${escHtml(f.handle)}" target="_blank" rel="noopener" style="color:var(--warn)">手动${actionText.verb}</a></div>` : ""}
+                ${f.blockActive && !f.blocked ? `<div class="qnote" style="color:var(--danger)">正在${actionText.background}${source}</div>` : ""}
+                ${f.blockQueued && !f.blockActive && !f.blocked ? `<div class="qnote" style="color:var(--brand)">待${actionText.background}${source}</div>` : ""}
+                ${f.blocked ? `<div class="qnote" style="color:var(--safe)">✓ ${actionText.done}${source}</div>` : ""}
               </div>
               <button class="${actClass}" data-one="${id}"${f.blocked || f.blockQueued || f.blockActive ? " disabled" : ""}>${actText}</button>
             </div>`;
@@ -921,10 +927,10 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
         actionableCount === 0 && activeCount === 0 && queuedCount === 0
           ? `<button class="btn" disabled style="background:var(--safe)">✓ 已全部处理 (${doneCount})</button>`
           : activeCount || queuedCount
-            ? `<button class="btn" disabled style="background:var(--brand)">后台拉黑中 · 正在 ${activeCount} · 待 ${queuedCount}</button>`
+            ? `<button class="btn" disabled style="background:var(--brand)">${actionText.background}中 · 正在 ${activeCount} · 待 ${queuedCount}</button>`
           : selectedPending === 0
             ? `<button class="btn" disabled style="opacity:.55">未选中任何账号 (剩余 ${actionableCount})</button>`
-            : `<button class="btn" data-block>一键拉黑选中 ${selectedPending}${doneCount ? ` · 已完成 ${doneCount}` : ""}${selectedPending < actionableCount ? ` · 跳过 ${actionableCount - selectedPending}` : ""}</button>`
+            : `<button class="btn" data-block>一键${actionText.verb}选中 ${selectedPending}${doneCount ? ` · 已完成 ${doneCount}` : ""}${selectedPending < actionableCount ? ` · 跳过 ${actionableCount - selectedPending}` : ""}</button>`
       }
       <div class="row"><span class="lnk" data-each>逐个查看处理</span>
         <span class="lnk" data-ign>忽略本页</span></div>`;
@@ -948,7 +954,7 @@ export function createBubble(h: BubbleHandlers, pos: "tr" | "br" = "tr") {
       });
     });
     // Per-row select toggle — uncheck excludes from the bulk action so the
-    // user can opt-out specific accounts before "一键拉黑".
+    // user can opt-out specific accounts before the bulk account action.
     card.querySelectorAll<HTMLInputElement>("[data-sel]").forEach((cb) => {
       cb.addEventListener("change", () => {
         const id = cb.dataset.sel;
@@ -1078,6 +1084,7 @@ export interface BadgeActions {
   onAppeal: () => void;
   onCheck?: () => void; // present => ghost manual-check state
   canReport?: boolean;
+  action?: ModerationAction;
 }
 
 interface ManualPopoverOptions {
@@ -1203,13 +1210,13 @@ function attachManualPopover(
         <div style="color:var(--muted);line-height:1.55">${escHtml(
           opts.description ??
             (hideCheck
-              ? "AI 正在分析中；如已确认可疑，可直接上报或拉黑并上报。"
-              : "未命中公榜时，可主动检查；确认可疑后再上报或拉黑并上报。"),
+              ? `AI 正在分析中；如已确认可疑，可直接上报或${actionLabels(a.action ?? "mute").verb}。`
+              : `未命中公榜时，可主动检查；确认可疑后再上报或${actionLabels(a.action ?? "mute").verb}。`),
         )}</div>
         <div class="acts">
           ${hideCheck ? "" : '<button data-c>检查</button>'}
           <button data-r>上报</button>
-          <button data-b>拉黑并上报</button>
+          <button data-b>${actionLabels(a.action ?? "mute").verb}</button>
         </div>`;
       if (!hideCheck) {
         manualPop.querySelector("[data-c]")?.addEventListener("click", () => {
@@ -1247,11 +1254,12 @@ export function createStatusBadge(
   a?: BadgeActions,
 ): HTMLElement {
   const el = document.createElement("span");
+  const labels = actionLabels(a?.action ?? "mute");
   if (kind === "analyzing") {
     el.className = "xss-badge analyzing labeled";
     el.setAttribute(
       "aria-label",
-      a?.canReport ? "MXGA 正在分析，可手动上报或拉黑并上报" : "MXGA 正在分析",
+      a?.canReport ? `MXGA 正在分析，可手动上报或${labels.verb}并上报` : "MXGA 正在分析",
     );
     el.innerHTML = `<span class="xss-ico">${icon("shield", "currentColor", 12)}</span><span class="xss-label">分析</span>`;
     if (a) attachManualPopover(el, a, { hideCheck: true });
@@ -1261,8 +1269,8 @@ export function createStatusBadge(
     el.innerHTML = `<span class="xss-ico">${icon("shield", "currentColor", 12)}</span><span class="xss-label">排队</span>`;
   } else {
     el.className = "xss-badge blocking labeled";
-    el.setAttribute("aria-label", "MXGA 已加入后台拉黑队列");
-    el.innerHTML = `<span class="xss-ico">${icon("shield-x", "currentColor", 12)}</span><span class="xss-label">屏蔽中</span>`;
+    el.setAttribute("aria-label", `MXGA 已加入${labels.background}队列`);
+    el.innerHTML = `<span class="xss-ico">${icon("shield-x", "currentColor", 12)}</span><span class="xss-label">${labels.gerund}</span>`;
   }
   return el;
 }
@@ -1285,8 +1293,9 @@ export function createBadge(
     return el;
   }
   if (!v) {
+    const labels = actionLabels(a.action ?? "mute");
     el.className = "xss-badge ghost labeled";
-    el.setAttribute("aria-label", a.canReport ? "MXGA：检查、上报或拉黑并上报" : "MXGA 手动检查");
+    el.setAttribute("aria-label", a.canReport ? `MXGA：检查、上报或${labels.verb}` : "MXGA 手动检查");
     el.innerHTML = `<span class="xss-ico">${icon("shield", "currentColor", 12)}</span><span class="xss-label">检查</span>`;
     attachManualPopover(el, a);
     return el;
@@ -1300,7 +1309,7 @@ export function createBadge(
   // Tier-specific tooltip + tag — tells the user exactly which gate matched.
   const tip =
     source === "list"
-      ? "公榜确认：≥1 个维护者已经把此账号公开拉黑"
+      ? "公榜确认：≥1 个维护者已经确认此账号"
       : source === "cache"
         ? "本地缓存命中：本机之前已经判过这个号"
         : "AI 现场判定：本次会话首次扫描，已记录待人工确认";
@@ -1340,7 +1349,7 @@ export function createBadge(
         <ul>${v.reasons.map((r) => `<li>${escHtml(r)}</li>`).join("")}</ul>
         ${note ? `<div style="color:var(--muted)">${escHtml(note)}</div>` : ""}
         <div class="acts">
-          ${spammy ? '<button data-b>拉黑</button><button data-h>隐藏</button>' : ""}
+          ${spammy ? `<button data-b>${actionLabels(a.action ?? "mute").verb}</button><button data-h>隐藏</button>` : ""}
           ${a.canReport ? '<button data-r>上报</button>' : ""}
           <button data-a>误判?</button>
         </div>`;

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     // Single-purpose description — what's shipped today, plus the framing
     // that anchors the brand: AI-driven, ambient, privacy-first.
     description:
-      "AI 驱动的 X 旁路扩展 · 你刷 X 时它在后台静默识别色情/广告 spam 机器人，给你一键真拉黑。完全开源，零数据收集。",
+      "AI 驱动的 X 旁路扩展 · 你刷 X 时它在后台静默识别色情/广告 spam 机器人，默认一键静音。完全开源，零数据收集。",
     // Optional but recommended — author + homepage_url improve listing trust.
     author: { email: "foru17@foxmail.com" },
     homepage_url: "https://x.zuoluo.tv",

--- a/test/moderation-action.test.ts
+++ b/test/moderation-action.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const { DEFAULT_MODERATION_ACTION, actionApiPath, actionLabels } = await import(
+  "../extension/lib/moderation-action.ts"
+);
+
+test("default moderation action is account mute", () => {
+  assert.equal(DEFAULT_MODERATION_ACTION, "mute");
+});
+
+test("mute uses X account mute endpoint, not sound muting", () => {
+  assert.equal(actionApiPath("mute"), "/i/api/1.1/mutes/users/create.json");
+  assert.equal(actionLabels("mute").verb, "静音");
+  assert.match(actionLabels("mute").description, /隐藏该用户的帖子/);
+});
+
+test("block remains available as an explicit higher-risk action", () => {
+  assert.equal(actionApiPath("block"), "/i/api/1.1/blocks/create.json");
+  assert.equal(actionLabels("block").verb, "拉黑");
+});


### PR DESCRIPTION
## 变更说明

这个 PR 将扩展的默认账号处理动作从「拉黑」改为「静音用户」。

「静音」这里指的是 X 的账号静音能力：隐藏该用户的帖子，不是声音静音。这样可以保留一键处理垃圾账号的体验，同时降低短时间大量 block 带来的 X 风控风险。

## 主要改动

- 新增 `moderationAction` 设置，默认值为 `mute`
- 默认调用 X 的账号静音接口：`/i/api/1.1/mutes/users/create.json`
- 保留 `block` 作为显式高风险选项，用户可在设置页切换为「拉黑用户」
- 设置页新增「默认账号处理动作」选择器
- 气泡、按钮、进度、自动处理文案改为根据当前动作显示「静音 / 拉黑」
- 手动静音保持本地私有处理，不再发送 `confirm_spam`
- 只有用户显式选择 block 时，才保留原有 `confirm_spam` 行为

## 截图

<img width="900" height="753" alt="image" src="https://github.com/user-attachments/assets/569a735a-5725-43cb-969c-ef59d1497c3f" />


## 验证

- `rtk ./node_modules/.bin/tsx --test test/moderation-action.test.ts`
- `rtk ./node_modules/.bin/tsc --noEmit`
- `rtk npm --prefix extension run compile`
- `rtk npm --prefix extension run build`
