### PR TITLE
feat(firefox): add Firefox Add-on build support

### DIFF
--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
   // .output/chrome-mv3 into your own Chrome (logged into X) manually;
   // WXT still watches + hot-reloads it.
   webExt: { disabled: true },
+  // data_collection_permissions is already declared in manifest below (none: true).
+  // This silences WXT's redundant build-time reminder.
+  suppressWarnings: { firefoxDataCollection: true },
   manifest: ({ mode }) => ({
     // Brand-forward name. CWS_LISTING.md keeps the fallback copy in case the
     // listing needs a more neutral store-facing title.
@@ -61,5 +64,8 @@ export default defineConfig({
     ],
     action: { default_title: "MXGA" },
     options_ui: { open_in_tab: true },
+    // Firefox AMO requirement (Nov 2025+): declare that this extension
+    // collects no user data. Matches the "零数据收集" promise in the description.
+    data_collection_permissions: { none: true },
   }),
 });


### PR DESCRIPTION
## 背景

MXGA 目前僅在 Chrome Web Store 分發。WXT（本 extension 使用的建置框架）內建 Firefox 支援，理論上可以零邏輯修改地產出 Firefox Add-on。本 PR 驗證並實現這一點。

## 本次改動

僅修改 `extension/wxt.config.ts`，無任何 extension 邏輯變動：

1. 新增 `data_collection_permissions: { none: true }` 至 manifest——符合 Firefox AMO 自 2025 年 11 月起對新擴充套件的強制要求，同時與 extension 描述中既有的「零数据收集」承諾一致。
2. 新增 `suppressWarnings: { firefoxDataCollection: true }`——告知 WXT 建置工具該欄位已正式宣告，消除冗餘的建置警告。

執行 `wxt build -b firefox` 可產出 `.output/firefox-mv2/`，已在 Firefox 151 實機載入並於 x.com 完成基本功能驗證。

## 测试验证

- [x] `pnpm typecheck` — 通過
- [x] `pnpm test` — 15/15 通過
- [ ] `pnpm lint` — 預先存在的 eslint 問題，與本 PR 無關（`extension/` 不在 biome 範圍內，且本 PR 不修改任何業務邏輯）
- [x] 未提交任何密鑰（`git status` 已確認）
- [x] `wxt build -b firefox` 零錯誤零警告
- [x] Firefox 151 實機測試：擴充套件載入正常，x.com 上功能運作正常

## 风险与回滚

低風險。Chrome 建置完全不受影響——`data_collection_permissions` 為 Firefox manifest 專屬欄位，Chrome 會忽略；`suppressWarnings` 為 WXT 建置時選項，不進入任何產出物。

回滾只需 revert 此 commit。

## 治理影响

- [x] 不削弱 GOVERNANCE.md 红线（无自动公开 / 范围 / 申诉 / 隐私 / 被动姿态）

本 PR 為純建置配置變更，不觸及任何偵測邏輯、資料處理或用戶帳號操作行為。

## 关联 Issue

N/A