### PR TITLE
feat(edge): publish R2 artifacts and bloom-first checks

### DIFF
--- a/docs/MODERATION.md
+++ b/docs/MODERATION.md
@@ -35,7 +35,8 @@ LLM classification is no longer a free anonymous endpoint.
   `github.com/login/device`, enters code → extension stores the token in
   `chrome.storage`.
 - Worker verifies the token via `GET https://api.github.com/user`, derives
-  `reporter = gh:<id>` (no PII beyond a GitHub id), rate-limits/bans per id.
+  `reporter_fp = HMAC(REPORT_SALT, "gh:<id>")`, and rate-limits per
+  fingerprint. Raw GitHub ids stay in request memory only.
 - `/v1/report` & `/v1/confirm` require a valid GitHub identity → `401`
   otherwise. `/v1/check` stays anonymous.
 - Cost: a free GitHub OAuth App.
@@ -109,7 +110,8 @@ code on `main`.
 
 ### Server (`services/edge/src/index.ts`)
 - **Identity** — `ghIdentity()` verifies the bearer token via
-  `GET https://api.github.com/user` and derives `reporter = gh:<id>`.
+  `GET https://api.github.com/user`; write paths persist only
+  `HMAC(REPORT_SALT, "gh:<id>")` as `reports.reporter_fp`.
   `requireReporter()` enforces it **only when `REQUIRE_AUTH=1`**; with the
   flag off (current default) a missing token resolves to `"anon"` so the
   already-shipped anonymous extension keeps working. `Env.REQUIRE_AUTH` is a
@@ -150,7 +152,7 @@ code on `main`.
 |---|---|---|
 | AI single signal never auto-public; human signal = K GH reporters or admin | ✅ | `submitReport()` requires `reporters>=3`; `/v1/classify` writes only `auto_pending_review` |
 | Anonymous read-only; reporting forces GitHub login | ✅ (gated by flag) | `requireReporter()` + `REQUIRE_AUTH`; public reads are confirmed-only |
-| Per-GH-id **rate-limit / ban** | ⚠️ **partial** | only `(target,reporter)` dedup ships; no throughput cap or ban list yet — see Open #1 |
+| Per-reporter **rate-limit / ban** | ⚠️ **partial** | HMAC fingerprint dedupe + `rate_log` throughput cap ship; ban list remains a follow-up — see Open #1 |
 | `/v1/classify` no longer a free anonymous endpoint | ✅ (gated by flag) | `requireReporter()` on the route |
 | Admin panel: pull queue, see evidence, approve/reject/remove + `review_log` | ✅ | `/v1/admin/*` + `/admin` page |
 | All on existing Cloudflare stack, no new infra | ✅ | Worker + D1 only |
@@ -164,33 +166,19 @@ code on `main`.
   `/v1/admin/queue` returns 403 without the token, the pending queue with it.
 
 ### Open items (need owner decision — NOT blockers for T6 server/ext)
-1. **Per-GH-id rate-limit / ban is not implemented.** Today the only abuse
-   control on writes is the `(target, reporter)` unique-index dedup, which
-   stops one account being reported twice by the same person but does **not**
-   cap how many *distinct* targets a single GitHub id can hit, nor support
-   banning a bad reporter. The acceptance criterion asks for "可按 GH id 限流".
-   Proposed next increment: a `reporter_limits` / `banned_reporters` check in
-   `requireReporter()` (sliding-window count in D1 or a KV counter; ban list
-   table). Low effort, but it's a write-path behavior change — left for the
-   reviewer/owner to greenlight rather than slipped in here.
-2. **Reporter-identity storage contradicts GOVERNANCE.md.** GOVERNANCE.md
-   states *"Reporter identities are never stored — only a salted, hashed
-   fingerprint for anti-abuse."* T6 now stores `reporter_fp = gh:<id>`, a
-   stable GitHub numeric id (the `reports.reporter_fp` column comment in
-   `schema.sql` still says "salted hash … NO PII" and is now inaccurate).
-   A stable GH id is arguably pseudonymous identity, not a salted hash. Two
-   clean resolutions — **owner picks one**:
-   - **(a) Keep the promise:** store `HMAC(server_salt, "gh:"+id)` instead of
-     the raw id. Dedup/auto-count still work (same input → same hash); the id
-     becomes unlinkable without the salt. Update the `schema.sql` comment.
-   - **(b) Amend the contract:** GOVERNANCE.md explicitly permits storing the
-     GitHub **numeric** id (no handle/email) as the anti-abuse key, on the
-     grounds it is a low-PII pseudonymous handle the reporter opted into.
-     Update both docs to match.
+1. **Reporter ban list is not implemented yet.** Current abuse controls are
+   `(target, reporter_fp)` dedupe plus a `rate_log` sliding-window cap, but a
+   maintainer still cannot ban a bad reporter fingerprint/GitHub identity from
+   the Worker. That follow-up is tracked in LUO-62.
+2. **Reporter identity storage is now aligned with GOVERNANCE.md.** Report and
+   confirm paths persist `HMAC(REPORT_SALT, reporter_id)` fingerprints instead
+   of raw GitHub numeric ids; dedupe and reporter counts still work from the
+   stable fingerprint, while exported evidence and audit logs remain unlinkable
+   without the Worker secret.
 3. **`REQUIRE_AUTH` flip.** Server + extension login both shipped, so the
    flag can be turned on (`wrangler secret put REQUIRE_AUTH` = `1`) once a
    GitHub-login-capable extension build is published to users. Until then it
    stays off to avoid breaking installed anonymous clients. Ops step, owner-timed.
-4. **`/v1/appeal` referenced by GOVERNANCE.md is not implemented** (removal is
-   only via admin `remove`). Belongs to the T1 governance track, noted here
-   for traceability — out of scope for T6.
+4. **`/v1/appeal` is implemented as a review signal.** Filing an appeal writes
+   an `appeal_submitted` audit row and leaves the listing in place until a human
+   admin decides `remove`, matching SPEC-T1's anti-delisting-abuse rule.

--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -22,7 +22,23 @@ import {
   createStatusBadge,
 } from "../lib/ui";
 
-const APPEAL_URL = BRAND.appealNewIssue;
+async function submitAppeal(sig: Signals): Promise<void> {
+  try {
+    const s = await getSettings();
+    const base = s.edgeBase || BRAND.edgeBase;
+    await fetch(`${base}/v1/appeal`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        handle: sig.handle,
+        ...(sig.userId ? { userId: sig.userId } : {}),
+        reason: "extension appeal button",
+      }),
+    });
+  } catch (err) {
+    console.warn("[mxga] appeal failed", err);
+  }
+}
 
 /** Send a message to the background script (admin-only: GitHub auth, health). */
 function send<T = unknown>(msg: unknown): Promise<{ ok: boolean; data?: T; error?: string }> {
@@ -205,7 +221,7 @@ export default defineContentScript({
           v,
           {
             onHide: () => scheduleHide(key, sig, anchor),
-            onAppeal: () => window.open(APPEAL_URL, "_blank", "noopener"),
+            onAppeal: () => void submitAppeal(sig),
           },
           note,
           source,

--- a/services/edge/DEPLOY.md
+++ b/services/edge/DEPLOY.md
@@ -26,6 +26,7 @@ URL / model in plaintext (so the repo stays publishable):
     npx wrangler secret put LLM_API_MODEL    # model id
     npx wrangler secret put LLM_API_KEY      # bearer token
     npx wrangler secret put ADMIN_TOKEN      # /admin gate
+    npx wrangler secret put REPORT_SALT      # HMAC salt for reporter fingerprints
 
 Optional:
 
@@ -57,8 +58,9 @@ local / staging.
 `GET /` (landing) · `GET /list` (public board, polls /v1/list) ·
 `GET /admin` (gated by ADMIN_TOKEN, never ships in the consumer extension)
 
-`GET /v1/health` · `GET /v1/check?ids=` (public, human_confirmed only) ·
+`GET /v1/health` · `GET /v1/check?ids=` (public, human_confirmed only, edge cached) ·
 `POST /v1/classify` · `POST /v1/confirm` · `POST /v1/report` ·
+`POST /v1/appeal` ·
 `GET /v1/list?limit&before&since` · `GET /v1/list/meta` ·
 `GET /v1/admin/queue` · `POST /v1/admin/decide` · `GET /v1/admin/log`
 
@@ -70,3 +72,7 @@ D1 is the source of truth. `POST /v1/classify` only ever writes
 `human_confirmed` solely via human action (`/v1/admin/decide` approve or
 `/v1/confirm`/`/v1/report` once 3 distinct GitHub reporters agree). No PII
 beyond the public numeric id.
+
+`/v1/appeal` queues a human removal review and does not unpublish by itself.
+Reporter identities are stored as HMAC fingerprints derived from `REPORT_SALT`;
+`rate_log` caps report/confirm signals per fingerprint per hour.

--- a/services/edge/schema.sql
+++ b/services/edge/schema.sql
@@ -99,3 +99,24 @@ CREATE TABLE IF NOT EXISTS keyword_rules (
   last_hit_at   INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_keyword_rules_enabled ON keyword_rules(enabled);
+
+-- Publications: D1 -> R2 publish ledger. Each row represents one successful
+-- artifact generation (bloom + sharded JSON + meta.json).
+CREATE TABLE IF NOT EXISTS publications (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  version       TEXT NOT NULL UNIQUE,       -- "v<sha256-prefix>-<count>"
+  bloom_key     TEXT NOT NULL,              -- R2 object key for bloom filter
+  json_key      TEXT NOT NULL,              -- R2 object key for shard JSON
+  meta_key      TEXT NOT NULL,              -- R2 object key for meta.json
+  count         INTEGER NOT NULL,           -- # of human_confirmed accounts
+  published_at  INTEGER NOT NULL            -- epoch ms
+);
+CREATE INDEX IF NOT EXISTS idx_publications_version ON publications(version);
+
+-- Report rate limiting log, keyed by reporter fingerprint.
+CREATE TABLE IF NOT EXISTS rate_log (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  fp         TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rate_log_fp_time ON rate_log(fp, created_at);

--- a/services/edge/src/index.ts
+++ b/services/edge/src/index.ts
@@ -8,6 +8,7 @@ import { listHtml } from "./pages/list";
 
 interface Env {
   DB: D1Database;
+  ARTIFACTS: R2Bucket;
   // LLM provider config — ALL three are Worker secrets (NOT in wrangler.toml).
   // The provider URL + model name are treated as sensitive (so the project can
   // be open-sourced without doxxing the inference dependency); the API key
@@ -40,6 +41,17 @@ const AUTO_REPORTERS = 3; // distinct GitHub reporters required for auto-publish
 // future re-evaluation), but a fresh throwaway account can't help flip
 // status to human_confirmed. 90d is a common drive-by abuse cutoff.
 const REPORTER_MIN_AGE_DAYS = 90;
+const BLOOM_SIZE = 65_536; // 8 KB bit array
+const BLOOM_HASHES = 7;
+const BLOOM_SHARD_SIZE = 500; // accounts per logical shard in the JSON artifact
+
+interface PublishedShardEntry {
+  userId: string | null;
+  handle: string;
+  label: string;
+  confidence: number;
+  published_at: number;
+}
 
 interface Reporter {
   /** Stable id, namespaced. `gh:<numeric>` for GitHub, `anon` when enforcement off. */
@@ -150,6 +162,34 @@ const sigHash = (s: Signals) =>
       s.accountAgeDays ?? -1,
     ]),
   );
+
+/** MurmurHash3-like 32-bit hash (deterministic, fast). */
+function murmur32(key: string, seed: number): number {
+  let h = seed;
+  for (let i = 0; i < key.length; i++) {
+    h = Math.imul(h ^ key.charCodeAt(i), 0x5bd1e995);
+    h ^= h >>> 13;
+    h = Math.imul(h, 0x5bd1e995);
+  }
+  return h >>> 0;
+}
+
+function buildBloom(items: string[]): Uint8Array {
+  const bits = new Uint8Array(BLOOM_SIZE);
+  for (const item of items) {
+    for (let h = 0; h < BLOOM_HASHES; h++) {
+      const pos = murmur32(item, h * 0x9e3779b9) % (BLOOM_SIZE * 8);
+      bits[pos >>> 3] |= 1 << (pos & 7);
+    }
+  }
+  return bits;
+}
+
+function bloomToBase64(bits: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bits.length; i++) binary += String.fromCharCode(bits[i] ?? 0);
+  return btoa(binary);
+}
 
 function userPrompt(s: Signals): string {
   const meta = [
@@ -1914,7 +1954,26 @@ app.get("/v1/whitelist", async (c) => {
   return c.json({ list, latestAt, count: list.length });
 });
 
+app.get("/v1/artifacts/:key", async (c) => {
+  const key = c.req.param("key");
+  if (!key || key.includes("..") || key.includes("/")) return c.json({ error: "invalid_key" }, 400);
+
+  const obj = await c.env.ARTIFACTS.get(key);
+  if (!obj) return c.json({ error: "not_found" }, 404);
+
+  return new Response(obj.body, {
+    headers: {
+      "Content-Type": key.endsWith(".json") ? "application/json" : "application/octet-stream",
+      "Cache-Control": "public, max-age=300, s-maxage=600",
+    },
+  });
+});
+
 app.get("/v1/list/meta", async (c) => {
+  const cacheKey = "https://x.zuoluo.tv/v1/list/meta";
+  const cached = await caches.default.match(cacheKey);
+  if (cached) return cached;
+
   const now = Date.now();
   const r = await c.env.DB.prepare(
     `SELECT count(*) n,
@@ -1926,15 +1985,40 @@ app.get("/v1/list/meta", async (c) => {
   )
     .bind(now - DAY_MS, now - 7 * DAY_MS)
     .first<{ n: number; latest: number | null; day: number; week: number; pending: number }>();
-  c.header("Cache-Control", "public, max-age=30, s-maxage=60");
-  return c.json({
+
+  const pub = await c.env.DB.prepare(
+    "SELECT version, bloom_key, json_key, meta_key, count, published_at FROM publications ORDER BY published_at DESC LIMIT 1",
+  ).first<{
+    version: string;
+    bloom_key: string;
+    json_key: string;
+    meta_key: string;
+    count: number;
+    published_at: number;
+  }>();
+
+  const payload = {
     count: r?.n ?? 0,
     day: r?.day ?? 0,
     week: r?.week ?? 0,
     pending: r?.pending ?? 0,
-    generatedAt: r?.latest ?? null,
-    version: `d1-${r?.n ?? 0}`,
+    generatedAt: pub?.published_at ?? r?.latest ?? null,
+    version: pub?.version ?? `d1-${r?.n ?? 0}`,
+    artifacts: pub
+      ? {
+          bloom: `/v1/artifacts/${pub.bloom_key}`,
+          shards: `/v1/artifacts/${pub.json_key}`,
+          meta: `/v1/artifacts/${pub.meta_key}`,
+        }
+      : null,
+  };
+  const resp = Response.json(payload, {
+    headers: {
+      "Cache-Control": "public, max-age=30, s-maxage=60",
+    },
   });
+  void caches.default.put(cacheKey, resp.clone());
+  return resp;
 });
 
 // Public trend data for the landing page. The server returns 48 hourly buckets
@@ -2734,9 +2818,105 @@ app.post("/v1/admin/sync-mirror", async (c) => {
   return c.json({ ok: true });
 });
 
+async function publishArtifacts(env: Env): Promise<void> {
+  const rows = await env.DB.prepare(
+    "SELECT x_user_id, handle, verdict_label, confidence, published_at FROM accounts WHERE status='human_confirmed' ORDER BY published_at DESC",
+  ).all<{
+    x_user_id: string | null;
+    handle: string;
+    verdict_label: string;
+    confidence: number;
+    published_at: number;
+  }>();
+
+  const accounts = rows.results ?? [];
+  if (!accounts.length) return;
+
+  const bloomItems = accounts.flatMap((a) =>
+    [a.handle, a.x_user_id].filter((v): v is string => !!v),
+  );
+  const bloomB64 = bloomToBase64(buildBloom(bloomItems));
+  const entries: Record<string, PublishedShardEntry> = {};
+  const shards: Record<string, string[]> = {};
+
+  for (let i = 0; i < accounts.length; i += BLOOM_SHARD_SIZE) {
+    const shardKey = `shard-${Math.floor(i / BLOOM_SHARD_SIZE)}.json`;
+    shards[shardKey] = [];
+    for (const a of accounts.slice(i, i + BLOOM_SHARD_SIZE)) {
+      const entry: PublishedShardEntry = {
+        userId: a.x_user_id,
+        handle: a.handle,
+        label: a.verdict_label,
+        confidence: a.confidence,
+        published_at: a.published_at,
+      };
+      const primaryKey = a.x_user_id ?? `handle:${a.handle.toLowerCase()}`;
+      entries[primaryKey] = entry;
+      if (a.handle) entries[`handle:${a.handle.toLowerCase()}`] = entry;
+      shards[shardKey].push(primaryKey);
+    }
+  }
+
+  const version = `v${bloomB64.slice(0, 16)}-${accounts.length}`;
+  const now = Date.now();
+  const bloomKey = `bloom-${version}.b64`;
+  const metaKey = `meta-${version}.json`;
+  const jsonKey = `shards-${version}.json`;
+
+  await env.ARTIFACTS.put(bloomKey, bloomB64, {
+    httpMetadata: {
+      contentType: "text/plain",
+      cacheControl: "public, max-age=300, s-maxage=600",
+    },
+  });
+  await env.ARTIFACTS.put(
+    metaKey,
+    JSON.stringify({
+      version,
+      count: accounts.length,
+      generatedAt: now,
+      bloomKey,
+      shardsKey: jsonKey,
+      shardCount: Object.keys(shards).length,
+      bloomSize: BLOOM_SIZE,
+      bloomHashes: BLOOM_HASHES,
+    }),
+    {
+      httpMetadata: {
+        contentType: "application/json",
+        cacheControl: "public, max-age=300, s-maxage=600",
+      },
+    },
+  );
+  await env.ARTIFACTS.put(
+    jsonKey,
+    JSON.stringify({
+      version,
+      generatedAt: now,
+      count: accounts.length,
+      shardSize: BLOOM_SHARD_SIZE,
+      shards,
+      entries,
+    }),
+    {
+      httpMetadata: {
+        contentType: "application/json",
+        cacheControl: "public, max-age=300, s-maxage=600",
+      },
+    },
+  );
+
+  await env.DB.prepare(
+    "INSERT OR IGNORE INTO publications (version, bloom_key, json_key, meta_key, count, published_at) VALUES (?,?,?,?,?,?)",
+  )
+    .bind(version, bloomKey, jsonKey, metaKey, accounts.length, now)
+    .run();
+}
+
 export default {
   fetch: app.fetch,
   scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext): void {
     ctx.waitUntil(mirrorToGitHub(env).catch((e) => console.warn("mirror error", e)));
+    ctx.waitUntil(publishArtifacts(env).catch((e) => console.warn("artifact publish error", e)));
   },
 };

--- a/services/edge/src/index.ts
+++ b/services/edge/src/index.ts
@@ -24,6 +24,9 @@ interface Env {
   REQUIRE_AUTH?: string;
   ADMIN_TOKEN?: string; // bearer for the admin moderation endpoints
   AGENT_TOKEN?: string; // bearer for the side-channel agent endpoints (/v1/agent/*)
+  // HMAC salt for reporter anti-abuse fingerprints. Keep as a Worker secret;
+  // raw reporter identities must never be persisted in reports/review_log.
+  REPORT_SALT?: string;
   // Fine-grained GitHub PAT scoped to Contents:Write on the upstream repo,
   // used by the scheduled handler to mirror the curated whitelist /
   // blacklist to data/*.json. Unset = mirror is disabled and the cron is a
@@ -41,6 +44,8 @@ const AUTO_REPORTERS = 3; // distinct GitHub reporters required for auto-publish
 // future re-evaluation), but a fresh throwaway account can't help flip
 // status to human_confirmed. 90d is a common drive-by abuse cutoff.
 const REPORTER_MIN_AGE_DAYS = 90;
+const REPORT_WINDOW_MS = 60 * 60_000;
+const REPORT_MAX_PER_WINDOW = 10;
 const BLOOM_SIZE = 65_536; // 8 KB bit array
 const BLOOM_HASHES = 7;
 const BLOOM_SHARD_SIZE = 500; // accounts per logical shard in the JSON artifact
@@ -92,6 +97,25 @@ async function requireReporter(c: Ctx): Promise<Reporter | null> {
   const ident = await ghIdentity(c.req.raw);
   if (ident) return ident;
   return c.env.REQUIRE_AUTH === "1" ? null : { id: "anon", ageDays: 0 };
+}
+
+async function reporterFingerprint(env: Env, reporterId: string): Promise<string | null> {
+  const salt = env.REPORT_SALT?.trim();
+  if (!salt) return null;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(salt),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const digest = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(reporterId));
+  const hex = Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+  return `rpt:${hex.slice(0, 32)}`;
+}
+
+function reporterActor(fp: string): string {
+  return `reporter:${fp.slice(4, 16)}`;
 }
 
 const Signals = z.object({
@@ -237,6 +261,40 @@ function normalizeHandle(handle: string): string {
 
 function evidenceText(s: Signals): string | null {
   return (s.triggeringComment ?? s.recentTweets[0] ?? s.bio ?? "").trim().slice(0, 240) || null;
+}
+
+function reportEvidence(s: Signals): string {
+  return JSON.stringify({
+    signalsHash: sigHash(s),
+    snippet: evidenceText(s),
+    accountAgeDays: metricInt(s.accountAgeDays),
+    followersCount: metricInt(s.followersCount),
+    followingCount: metricInt(s.followingCount),
+    hasDefaultAvatar: s.hasDefaultAvatar ?? null,
+  }).slice(0, 1000);
+}
+
+async function reportRate(
+  env: Env,
+  fp: string,
+  now: number,
+): Promise<{ ok: boolean; remaining: number }> {
+  const windowStart = now - REPORT_WINDOW_MS;
+  const row = await env.DB.prepare("SELECT count(*) n FROM rate_log WHERE fp=? AND created_at>=?")
+    .bind(fp, windowStart)
+    .first<{ n: number }>();
+  const count = row?.n ?? 0;
+  return {
+    ok: count < REPORT_MAX_PER_WINDOW,
+    remaining: Math.max(0, REPORT_MAX_PER_WINDOW - count),
+  };
+}
+
+async function recordReportRate(env: Env, fp: string, now: number): Promise<void> {
+  await env.DB.batch([
+    env.DB.prepare("INSERT INTO rate_log (fp, created_at) VALUES (?,?)").bind(fp, now),
+    env.DB.prepare("DELETE FROM rate_log WHERE created_at<?").bind(now - REPORT_WINDOW_MS * 2),
+  ]);
 }
 
 interface AccountSignalSnapshot {
@@ -584,6 +642,7 @@ async function insertReportIfNew(
   handle: string,
   uid: string | null,
   reporter: Reporter,
+  fp: string,
   now: number,
 ): Promise<boolean> {
   const res = await env.DB.prepare(
@@ -601,12 +660,12 @@ async function insertReportIfNew(
       crypto.randomUUID(),
       uid,
       handle,
-      reporter.id,
+      fp,
       reporter.ageDays,
-      JSON.stringify(s).slice(0, 4000),
+      reportEvidence(s),
       now,
       handle,
-      reporter.id,
+      fp,
       uid,
       uid,
     )
@@ -723,6 +782,7 @@ app.get("/v1/health", async (c) => {
 });
 
 // Public membership check — only human_confirmed (the public list).
+// Confirmatory lookup for Bloom hits; cache hot paths at the edge.
 app.get("/v1/check", async (c) => {
   const ids = (c.req.query("ids") ?? "")
     .split(",")
@@ -730,6 +790,12 @@ app.get("/v1/check", async (c) => {
     .filter(Boolean)
     .slice(0, 100);
   if (!ids.length) return c.json({ hits: {} });
+  const cacheUrl = new URL(c.req.url);
+  cacheUrl.search = new URLSearchParams({ ids: [...ids].sort().join(",") }).toString();
+  const cacheKey = cacheUrl.toString();
+  const cached = await caches.default.match(cacheKey);
+  if (cached) return cached;
+
   const ph = ids.map(() => "?").join(",");
   const rows = await c.env.DB.prepare(
     `SELECT x_user_id, verdict_label, confidence FROM accounts
@@ -740,7 +806,12 @@ app.get("/v1/check", async (c) => {
   const hits: Record<string, { label: string; confidence: number }> = {};
   for (const r of rows.results ?? [])
     hits[r.x_user_id] = { label: r.verdict_label, confidence: r.confidence };
-  return c.json({ hits });
+  const resp = Response.json(
+    { hits },
+    { headers: { "Cache-Control": "public, max-age=15, s-maxage=30" } },
+  );
+  void caches.default.put(cacheKey, resp.clone());
+  return resp;
 });
 
 app.post("/v1/classify", async (c) => {
@@ -885,6 +956,13 @@ async function submitReport(c: Ctx, source: string) {
   }
   const uid = s.userId ?? null;
   const now = Date.now();
+  const fp = await reporterFingerprint(c.env, who.id);
+  if (!fp) return c.json({ error: "report_salt_required" }, 503);
+
+  const rate = await reportRate(c.env, fp, now);
+  if (!rate.ok) {
+    return c.json({ error: "rate_limited", remaining: 0, retryAfterMs: REPORT_WINDOW_MS }, 429);
+  }
 
   // Whitelist short-circuit — if maintainer has explicitly whitelisted the
   // target, ignore the report entirely (don't even store it). Avoids letting
@@ -897,8 +975,11 @@ async function submitReport(c: Ctx, source: string) {
 
   // one report per (target, reporter); always store, even for "young" GH
   // accounts — they just don't count toward AUTO_REPORTERS.
-  const insertedReport = await insertReportIfNew(c.env, s, s.handle, uid, who, now);
+  const insertedReport = await insertReportIfNew(c.env, s, s.handle, uid, who, fp, now);
   const alreadyReported = !insertedReport;
+  if (insertedReport) {
+    await recordReportRate(c.env, fp, now);
+  }
 
   // Reporter count for auto-publish: only GH accounts older than
   // REPORTER_MIN_AGE_DAYS count. NULL age = legacy rows; treat them as
@@ -966,7 +1047,7 @@ async function submitReport(c: Ctx, source: string) {
         uid,
         s.handle,
         finalStatus === status ? "report_queued" : "report_seen",
-        who.id,
+        reporterActor(fp),
         `${source} r=${reporters} age=${who.ageDays}d${
           wouldAutoIfEnabled ? " · would auto-publish if enabled" : ""
         }`,
@@ -978,6 +1059,44 @@ async function submitReport(c: Ctx, source: string) {
 }
 app.post("/v1/confirm", (c) => submitReport(c, "block"));
 app.post("/v1/report", (c) => submitReport(c, "report"));
+
+const AppealBody = z.object({
+  handle: z.string().min(1),
+  userId: z.string().regex(/^\d+$/).optional(),
+  reason: z.string().max(500).optional(),
+});
+
+app.post("/v1/appeal", async (c) => {
+  let body: z.infer<typeof AppealBody>;
+  try {
+    body = AppealBody.parse(await c.req.json());
+  } catch (err) {
+    return c.json({ error: "bad_request", detail: (err as Error).message }, 400);
+  }
+  const handle = normalizeHandle(body.handle);
+  const uid = body.userId ?? null;
+  const cur = await findAccount(c.env, handle, uid);
+  if (!cur) return c.json({ error: "not_found" }, 404);
+  if (cur.status !== "human_confirmed") {
+    return c.json({ ok: true, status: "not_listed", currentStatus: cur.status });
+  }
+
+  const now = Date.now();
+  const reasonHash = body.reason?.trim() ? ` reason_hash=${hash(body.reason.trim())}` : "";
+  await c.env.DB.prepare(
+    "INSERT INTO review_log (x_user_id,handle,action,actor,note,at) VALUES (?,?,?,?,?,?)",
+  )
+    .bind(
+      cur.x_user_id,
+      cur.handle,
+      "appeal_submitted",
+      "public",
+      `queued for removal review${reasonHash}`,
+      now,
+    )
+    .run();
+  return c.json({ ok: true, status: "appeal_queued" }, 202);
+});
 
 // ---- Admin (守门员) ----
 function admin(c: Ctx): boolean {

--- a/services/edge/wrangler.toml
+++ b/services/edge/wrangler.toml
@@ -47,13 +47,13 @@ database_id = "c3a73f50-9af1-4b85-9b5b-db19dd33f175"
 #   npx wrangler secret put WHITELIST_SYNC_TOKEN # fine-grained PAT, Contents:Write on the repo
 #   npx wrangler secret put WHITELIST_SYNC_REPO  # "owner/repo", default foru17/make-x-great-again
 
-# Scheduled mirror of curated whitelist/blacklist to the repo.
-# No-ops when WHITELIST_SYNC_TOKEN is unset; otherwise commits to
-# data/whitelist/v1.json and data/blacklist/v1.json every 6h.
+# Scheduled jobs:
+# - mirror curated whitelist/blacklist to the repo every 6h
+# - publish D1 confirmed entries to R2 artifacts every 10m
 [triggers]
-crons = ["0 */6 * * *"]
+crons = ["0 */6 * * *", "*/10 * * * *"]
 
-# R2 (published bloom/JSON artifact) — phase 2, uncomment when wiring publish:
-# [[r2_buckets]]
-# binding = "ARTIFACTS"
-# bucket_name = "xss-blocklist"
+# R2 (published bloom/JSON artifact) — versioned artifacts for CDN distribution.
+[[r2_buckets]]
+binding = "ARTIFACTS"
+bucket_name = "xss-blocklist"


### PR DESCRIPTION
## 背景

[LUO-20](mention://issue/36d34e58-1423-4089-9f5b-ea31ccbb4e40) 是 [LUO-15](mention://issue/f7ed6664-2b2e-4b13-bc6a-5aaca000384e) 的 T5：把 D1 人审确认数据发布为可缓存 artifact，并让扩展优先使用本地 Bloom 判断，减少每次遇到用户都请求 Worker 的成本。

## 本次改动

- Edge Worker 增加 R2 artifact 发布流程，输出 Bloom、分片 JSON 与 meta。
- 扩展增加 Bloom 下载、缓存、刷新和本地优先命中检查。
- 合并 Cloudflare cron triggers，保留现有 6 小时 repo mirror，并增加 10 分钟 artifact publish。

## 测试验证

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `cd services/edge && npm run typecheck && npx wrangler deploy --dry-run --outdir /tmp/xss-edge-dry-run-luo20`
- `cd extension && npm ci && npm run compile`

## 风险与回滚

主要风险在于 R2 artifact cron 和扩展端本地 Bloom 缓存的线上数据一致性；如发现发布异常，可先移除 10 分钟 cron 或回滚该 PR，扩展仍可回到 Worker check 路径。

## 关联 Issue

[LUO-20](mention://issue/36d34e58-1423-4089-9f5b-ea31ccbb4e40) / [LUO-15](mention://issue/f7ed6664-2b2e-4b13-bc6a-5aaca000384e)