### PR TITLE
feat: add reporter identity controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@
 LLM_BASE_URL=https://api.example.com/v1
 LLM_API_KEY=your-key-here
 LLM_MODEL=your-model-id
+REPORT_SALT=replace-with-a-long-random-secret
+REQUIRE_AUTH=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         with: { node-version: 22 }
       - run: npm install --no-audit --no-fund
       - run: npx tsc --noEmit
-      - run: npm test
       - run: npx wxt build
 
   edge:
@@ -43,3 +42,4 @@ jobs:
         with: { node-version: 22 }
       - run: npm install --no-audit --no-fund
       - run: npx tsc --noEmit
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         with: { node-version: 22 }
       - run: npm install --no-audit --no-fund
       - run: npx tsc --noEmit
+      - run: npm test
       - run: npx wxt build
 
   edge:

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -43,6 +43,7 @@ Every migration must:
 | 2026-05-28 | `2026-05-28-public-trends.sql` | ⏳ apply before relying on `/v1/list/trends` at scale | adds `idx_accounts_status_published_at` | Speeds up public count/window queries and trend buckets. Companion rollback drops only this index. |
 | 2026-05-28 | `2026-05-28-account-profile-metrics.sql` | ⏳ apply before deploying admin metrics UI | adds nullable `account_created_at`, `account_age_days`, `followers_count`, `following_count` | Persists profile metrics already captured by the extension so `/admin` can show registration time, followers, and following counts. Rollback leaves nullable columns in place. |
 | 2026-05-29 | `2026-05-29-admin-sort-indexes.sql` | ⏳ apply before relying on admin metric sorting at scale | adds `status + account_created_at/followers_count/following_count` indexes | Helps admin queue/list endpoints sort and page by captured profile metrics. Companion rollback drops only these indexes. |
+| 2026-06-04 | `2026-06-04-reporter-bans.sql` | ⏳ apply before using reporter bans | adds `reporter_bans` table + active lookup index | Enables `/v1/admin/reporter-bans` and `/v1/admin/reporter-fingerprints/backfill`. After setting `REPORT_SALT`, run the backfill endpoint once before enforcing `REQUIRE_AUTH=1` in production. |
 
 Rollback: `2026-05-26-identity-cleanup.rollback.sql` (restores the
 `accounts` rows; `reports` deletes are not recoverable from migration data).

--- a/docs/MODERATION.md
+++ b/docs/MODERATION.md
@@ -1,8 +1,11 @@
 # Trust tiers, GitHub-gated reporting & admin moderation
 
-Status: **implemented** (server + extension + admin console shipped on the
-existing Cloudflare stack). Extends [GOVERNANCE.md](../GOVERNANCE.md) and the Cloudflare
-architecture. The design rationale below is unchanged; see **As-built (T6)**
+Status: **implemented for the Worker/admin surface** on the existing Cloudflare
+stack. The consumer extension is intentionally passive/local-list-only after
+the T5/T6 rollout, so report/confirm/classify write APIs are operated by
+trusted tooling/admin flows rather than exposed in the installed extension.
+Extends [GOVERNANCE.md](../GOVERNANCE.md) and the Cloudflare architecture.
+The design rationale below is unchanged; see **As-built (T6)**
 at the end for what actually shipped, the acceptance-criteria map, the
 verification points, and the two items still open for owner decision.
 
@@ -22,7 +25,7 @@ The moderation design protects three high-risk surfaces:
 | Tier | Who | Can do |
 |---|---|---|
 | **Anonymous** | any installed extension | **read only**: `/v1/check`, fetch public list/bloom. Cheap, cacheable, no abuse surface. Local heuristic + local cache still work. |
-| **Verified reporter** | signed in with **GitHub** | `/v1/report`. Rate-limited & bannable *per GitHub account*. |
+| **Verified reporter** | trusted caller with a **GitHub** bearer token | `/v1/report` / `/v1/confirm`. Rate-limited & bannable per HMAC reporter fingerprint. |
 | **Admin (守门员)** | maintainer allowlist | moderation panel: approve / reject / remove. |
 
 Key move: **separate cheap public reads from costly/abusable writes.** Server
@@ -30,15 +33,14 @@ LLM classification is no longer a free anonymous endpoint.
 
 ## GitHub-gated reporting (feasible, well-trodden)
 
-- Extension uses **GitHub OAuth Device Flow** (best for extensions — no
-  redirect-URI hassle): user clicks "用 GitHub 登录以上报" → opens
-  `github.com/login/device`, enters code → extension stores the token in
-  `chrome.storage`.
+- A trusted client may use **GitHub OAuth Device Flow** (best for browser-like
+  clients — no redirect-URI hassle): user clicks "用 GitHub 登录以上报" → opens
+  `github.com/login/device`, enters code → the client stores the token locally.
 - Worker verifies the token via `GET https://api.github.com/user`, derives
   `reporter_fp = HMAC(REPORT_SALT, "gh:<id>")`, and rate-limits per
   fingerprint. Raw GitHub ids stay in request memory only.
-- `/v1/report` & `/v1/confirm` require a valid GitHub identity → `401`
-  otherwise. `/v1/check` stays anonymous.
+- `/v1/report` & `/v1/confirm` require a valid GitHub identity when
+  `REQUIRE_AUTH=1` → `401` otherwise. `/v1/check` stays anonymous.
 - Cost: a free GitHub OAuth App.
 
 ## Report → AI → auto / queue → admin (the gatekeeper pipeline)
@@ -89,7 +91,7 @@ All on the existing Cloudflare stack.
 
 ## Current policy
 
-1. **`/v1/classify` = GitHub-authed only.** Anonymous installs get
+1. **`/v1/classify` = GitHub-authed when `REQUIRE_AUTH=1`.** Anonymous installs get
    read-only public list (`/v1/check`) + local heuristic + local cache.
    Server-side AI classification requires GitHub login. The server LLM key
    is never an anonymous endpoint. (UX implication: not-logged-in users
@@ -132,13 +134,11 @@ code on `main`.
   `ADMIN_TOKEN` secret. Every decision writes `review_log`.
 
 ### Extension (consumer, no admin surface)
-- GitHub **Device Flow** login in the background service worker
-  (`extension/entrypoints/background.ts`: `ghStart` → `login/device/code`,
-  `ghPoll` → `access_token` → `GET /user`). Token + login stored via
-  `extension/lib/auth.ts` (`chrome.storage.local`), public client id
-  `GH_CLIENT_ID` is a build constant (device flow has no secret).
-- `authedPost()` attaches `Authorization: Bearer <token>` to `/v1/classify`
-  and `/v1/confirm`. Login UI lives in `extension/entrypoints/options/App.tsx`.
+- The shipped consumer extension is passive and local-list-only. Its background
+  script returns explicit disabled errors for `gh_start` / `gh_poll`, and there
+  is no report/confirm/classify write path in normal content scanning.
+- `误判?` posts anonymous `POST /v1/appeal` as a review signal. Appeals do not
+  unpublish rows; admin `remove` is still the human decision point.
 
 ### Admin console (standalone, never in the extension)
 - `GET /admin` serves a self-contained page (`services/edge/src/pages/admin.ts`);
@@ -151,8 +151,8 @@ code on `main`.
 | Criterion | Status | Evidence |
 |---|---|---|
 | AI single signal never auto-public; human signal = K GH reporters or admin | ✅ | `submitReport()` requires `reporters>=3`; `/v1/classify` writes only `auto_pending_review` |
-| Anonymous read-only; reporting forces GitHub login | ✅ (gated by flag) | `requireReporter()` + `REQUIRE_AUTH`; public reads are confirmed-only |
-| Per-reporter **rate-limit / ban** | ⚠️ **partial** | HMAC fingerprint dedupe + `rate_log` throughput cap ship; ban list remains a follow-up — see Open #1 |
+| Anonymous read-only; reporting forces GitHub login | ✅ (gated by flag) | `requireReporter()` + `REQUIRE_AUTH`; public reads are confirmed-only; consumer extension has no write path |
+| Per-reporter **rate-limit / ban** | ✅ | HMAC fingerprint dedupe + `rate_log` throughput cap + `reporter_bans` admin API |
 | `/v1/classify` no longer a free anonymous endpoint | ✅ (gated by flag) | `requireReporter()` on the route |
 | Admin panel: pull queue, see evidence, approve/reject/remove + `review_log` | ✅ | `/v1/admin/*` + `/admin` page |
 | All on existing Cloudflare stack, no new infra | ✅ | Worker + D1 only |
@@ -165,20 +165,22 @@ code on `main`.
   3 anonymous reports on one target → `reporters=1`, not auto-published;
   `/v1/admin/queue` returns 403 without the token, the pending queue with it.
 
-### Open items (need owner decision — NOT blockers for T6 server/ext)
-1. **Reporter ban list is not implemented yet.** Current abuse controls are
-   `(target, reporter_fp)` dedupe plus a `rate_log` sliding-window cap, but a
-   maintainer still cannot ban a bad reporter fingerprint/GitHub identity from
-   the Worker. That follow-up is tracked in LUO-62.
-2. **Reporter identity storage is now aligned with GOVERNANCE.md.** Report and
+### Open items (owner-timed rollout)
+1. **Reporter identity storage is aligned with GOVERNANCE.md.** Report and
    confirm paths persist `HMAC(REPORT_SALT, reporter_id)` fingerprints instead
    of raw GitHub numeric ids; dedupe and reporter counts still work from the
    stable fingerprint, while exported evidence and audit logs remain unlinkable
    without the Worker secret.
-3. **`REQUIRE_AUTH` flip.** Server + extension login both shipped, so the
-   flag can be turned on (`wrangler secret put REQUIRE_AUTH` = `1`) once a
-   GitHub-login-capable extension build is published to users. Until then it
-   stays off to avoid breaking installed anonymous clients. Ops step, owner-timed.
+2. **Legacy fingerprint backfill.** If any old `gh:<id>` reporter rows exist,
+   set `REPORT_SALT`, apply `2026-06-04-reporter-bans.sql`, then call
+   `POST /v1/admin/reporter-fingerprints/backfill` once before relying on
+   `REQUIRE_AUTH=1`. Runtime dedupe also treats the current request's legacy
+   and HMAC aliases as the same reporter to prevent double-counting during the
+   transition.
+3. **`REQUIRE_AUTH` flip.** This is an owner-timed production operation:
+   confirm trusted write clients can supply GitHub bearer tokens, then set
+   `wrangler secret put REQUIRE_AUTH` to `1`. The consumer extension remains
+   read-only and is unaffected for `/v1/check` and local-list usage.
 4. **`/v1/appeal` is implemented as a review signal.** Filing an appeal writes
    an `appeal_submitted` audit row and leaves the listing in place until a human
    admin decides `remove`, matching SPEC-T1's anti-delisting-abuse rule.

--- a/services/edge/DEPLOY.md
+++ b/services/edge/DEPLOY.md
@@ -45,6 +45,13 @@ by default for the personal account).
     npm run deploy
     # → https://x.zuoluo.tv     (workers.dev URL still works as a fallback)
 
+Before enabling reporter bans or a `REQUIRE_AUTH=1` rollout, apply the reporter
+ban migration and backfill any legacy `gh:<id>` fingerprints:
+
+    npx wrangler d1 execute xss-db --remote --file=./migrations/2026-06-04-reporter-bans.sql
+    curl -X POST https://x.zuoluo.tv/v1/admin/reporter-fingerprints/backfill \
+      -H "x-admin-token: $ADMIN_TOKEN"
+
 ## 5. Point the extension at it
 
 The extension defaults to `BRAND.edgeBase` (= `https://x.zuoluo.tv`) via
@@ -62,7 +69,8 @@ local / staging.
 `POST /v1/classify` · `POST /v1/confirm` · `POST /v1/report` ·
 `POST /v1/appeal` ·
 `GET /v1/list?limit&before&since` · `GET /v1/list/meta` ·
-`GET /v1/admin/queue` · `POST /v1/admin/decide` · `GET /v1/admin/log`
+`GET /v1/admin/queue` · `POST /v1/admin/decide` · `GET /v1/admin/log` ·
+`GET/POST/DELETE /v1/admin/reporter-bans`
 
 ## Governance
 
@@ -75,4 +83,6 @@ beyond the public numeric id.
 
 `/v1/appeal` queues a human removal review and does not unpublish by itself.
 Reporter identities are stored as HMAC fingerprints derived from `REPORT_SALT`;
-`rate_log` caps report/confirm signals per fingerprint per hour.
+`rate_log` caps report/confirm signals per fingerprint per hour, and
+`reporter_bans` blocks abusive fingerprints before any effective signal is
+written.

--- a/services/edge/migrations/2026-06-04-reporter-bans.rollback.sql
+++ b/services/edge/migrations/2026-06-04-reporter-bans.rollback.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_reporter_bans_fp_active;
+DROP TABLE IF EXISTS reporter_bans;

--- a/services/edge/migrations/2026-06-04-reporter-bans.sql
+++ b/services/edge/migrations/2026-06-04-reporter-bans.sql
@@ -1,0 +1,12 @@
+-- LUO-62 reporter ban controls.
+CREATE TABLE IF NOT EXISTS reporter_bans (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  reporter_fp   TEXT NOT NULL,
+  reason        TEXT,
+  created_by    TEXT NOT NULL DEFAULT 'admin',
+  created_at    INTEGER NOT NULL,
+  expires_at    INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_reporter_bans_fp_active
+  ON reporter_bans(reporter_fp, expires_at);

--- a/services/edge/package-lock.json
+++ b/services/edge/package-lock.json
@@ -14,6 +14,8 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241218.0",
+        "@types/node": "^22.10.2",
+        "tsx": "^4.19.2",
         "typescript": "^5.7.2",
         "wrangler": "^4.92.0"
       }
@@ -134,8 +136,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260518.1.tgz",
       "integrity": "sha512-xXzGrbRi8RHRBNQFgXYkzrB4DgF0RXvmp8E1vCxoBmINpeitM/ZjVDd1CNC+N3uXjgcNjacoz4OgTa0rxgig1A==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1170,6 +1171,16 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -1401,6 +1412,509 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1425,13 +1939,19 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -1443,7 +1963,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/services/edge/package.json
+++ b/services/edge/package.json
@@ -10,7 +10,8 @@
     "deploy": "wrangler deploy",
     "db:init": "wrangler d1 execute xss-db --file=./schema.sql",
     "db:init:remote": "wrangler d1 execute xss-db --remote --file=./schema.sql",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test test/**/*.test.ts"
   },
   "dependencies": {
     "hono": "^4.6.14",
@@ -18,6 +19,8 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241218.0",
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "wrangler": "^4.92.0"
   }

--- a/services/edge/schema.sql
+++ b/services/edge/schema.sql
@@ -120,3 +120,17 @@ CREATE TABLE IF NOT EXISTS rate_log (
   created_at INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_rate_log_fp_time ON rate_log(fp, created_at);
+
+-- Reporter bans: admin-maintained anti-abuse blocklist keyed by the same
+-- HMAC reporter fingerprint used by reports/rate_log. Temporary bans expire
+-- automatically when expires_at is in the past; NULL = permanent.
+CREATE TABLE IF NOT EXISTS reporter_bans (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  reporter_fp   TEXT NOT NULL,
+  reason        TEXT,
+  created_by    TEXT NOT NULL DEFAULT 'admin',
+  created_at    INTEGER NOT NULL,
+  expires_at    INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_reporter_bans_fp_active
+  ON reporter_bans(reporter_fp, expires_at);

--- a/services/edge/src/index.ts
+++ b/services/edge/src/index.ts
@@ -118,6 +118,11 @@ function reporterActor(fp: string): string {
   return `reporter:${fp.slice(4, 16)}`;
 }
 
+function reporterAliases(fp: string, reporterId: string): [string, string] {
+  const legacy = reporterId.startsWith("gh:") ? reporterId : fp;
+  return legacy === fp ? [fp, fp] : [fp, legacy];
+}
+
 const Signals = z.object({
   // X numeric user id — immutable, the canonical identity key. Optional
   // because the fiber-walk that extracts it from X's React state fails on
@@ -276,12 +281,14 @@ function reportEvidence(s: Signals): string {
 
 async function reportRate(
   env: Env,
-  fp: string,
+  aliases: [string, string],
   now: number,
 ): Promise<{ ok: boolean; remaining: number }> {
   const windowStart = now - REPORT_WINDOW_MS;
-  const row = await env.DB.prepare("SELECT count(*) n FROM rate_log WHERE fp=? AND created_at>=?")
-    .bind(fp, windowStart)
+  const row = await env.DB.prepare(
+    "SELECT count(*) n FROM rate_log WHERE fp IN (?,?) AND created_at>=?",
+  )
+    .bind(aliases[0], aliases[1], windowStart)
     .first<{ n: number }>();
   const count = row?.n ?? 0;
   return {
@@ -295,6 +302,25 @@ async function recordReportRate(env: Env, fp: string, now: number): Promise<void
     env.DB.prepare("INSERT INTO rate_log (fp, created_at) VALUES (?,?)").bind(fp, now),
     env.DB.prepare("DELETE FROM rate_log WHERE created_at<?").bind(now - REPORT_WINDOW_MS * 2),
   ]);
+}
+
+async function activeReporterBan(
+  env: Env,
+  aliases: [string, string],
+  now: number,
+): Promise<{ id: number; reporter_fp: string; reason: string | null } | null> {
+  return (
+    (await env.DB.prepare(
+      `SELECT id, reporter_fp, reason
+         FROM reporter_bans
+        WHERE reporter_fp IN (?,?)
+          AND (expires_at IS NULL OR expires_at > ?)
+        ORDER BY created_at DESC
+        LIMIT 1`,
+    )
+      .bind(aliases[0], aliases[1], now)
+      .first<{ id: number; reporter_fp: string; reason: string | null }>()) ?? null
+  );
 }
 
 interface AccountSignalSnapshot {
@@ -643,6 +669,7 @@ async function insertReportIfNew(
   uid: string | null,
   reporter: Reporter,
   fp: string,
+  aliases: [string, string],
   now: number,
 ): Promise<boolean> {
   const res = await env.DB.prepare(
@@ -652,7 +679,7 @@ async function insertReportIfNew(
       WHERE NOT EXISTS (
         SELECT 1 FROM reports
          WHERE lower(handle)=?
-           AND reporter_fp=?
+           AND reporter_fp IN (?,?)
            AND (? IS NULL OR x_user_id IS NULL OR x_user_id=?)
       )`,
   )
@@ -665,7 +692,8 @@ async function insertReportIfNew(
       reportEvidence(s),
       now,
       handle,
-      fp,
+      aliases[0],
+      aliases[1],
       uid,
       uid,
     )
@@ -958,8 +986,14 @@ async function submitReport(c: Ctx, source: string) {
   const now = Date.now();
   const fp = await reporterFingerprint(c.env, who.id);
   if (!fp) return c.json({ error: "report_salt_required" }, 503);
+  const aliases = reporterAliases(fp, who.id);
 
-  const rate = await reportRate(c.env, fp, now);
+  const ban = await activeReporterBan(c.env, aliases, now);
+  if (ban) {
+    return c.json({ error: "reporter_banned", reason: ban.reason ?? "banned" }, 403);
+  }
+
+  const rate = await reportRate(c.env, aliases, now);
   if (!rate.ok) {
     return c.json({ error: "rate_limited", remaining: 0, retryAfterMs: REPORT_WINDOW_MS }, 429);
   }
@@ -975,7 +1009,7 @@ async function submitReport(c: Ctx, source: string) {
 
   // one report per (target, reporter); always store, even for "young" GH
   // accounts — they just don't count toward AUTO_REPORTERS.
-  const insertedReport = await insertReportIfNew(c.env, s, s.handle, uid, who, fp, now);
+  const insertedReport = await insertReportIfNew(c.env, s, s.handle, uid, who, fp, aliases, now);
   const alreadyReported = !insertedReport;
   if (insertedReport) {
     await recordReportRate(c.env, fp, now);
@@ -985,12 +1019,12 @@ async function submitReport(c: Ctx, source: string) {
   // REPORTER_MIN_AGE_DAYS count. NULL age = legacy rows; treat them as
   // eligible so existing maintainer history is preserved.
   const cnt = await c.env.DB.prepare(
-    `SELECT count(DISTINCT reporter_fp) n FROM reports
+    `SELECT count(DISTINCT CASE WHEN reporter_fp=? THEN ? ELSE reporter_fp END) n FROM reports
        WHERE lower(handle)=?
          AND (? IS NULL OR x_user_id IS NULL OR x_user_id=?)
          AND (reporter_age_days IS NULL OR reporter_age_days >= ?)`,
   )
-    .bind(s.handle, uid, uid, REPORTER_MIN_AGE_DAYS)
+    .bind(aliases[1], aliases[0], s.handle, uid, uid, REPORTER_MIN_AGE_DAYS)
     .first<{ n: number }>();
   const reporters = cnt?.n ?? (who.ageDays >= REPORTER_MIN_AGE_DAYS ? 1 : 0);
   if (alreadyReported && cur) {
@@ -1103,6 +1137,99 @@ function admin(c: Ctx): boolean {
   const t = c.env.ADMIN_TOKEN;
   return !!t && c.req.raw.headers.get("x-admin-token") === t;
 }
+
+const ReporterBanBody = z
+  .object({
+    reporterFp: z.string().min(1).max(128).optional(),
+    githubId: z.string().regex(/^\d+$/).optional(),
+    reason: z.string().max(500).optional(),
+    expiresAt: z.number().int().positive().nullable().optional(),
+  })
+  .refine((v) => !!v.reporterFp !== !!v.githubId, {
+    message: "provide exactly one of reporterFp or githubId",
+  });
+
+async function reporterFpForAdmin(
+  env: Env,
+  body: z.infer<typeof ReporterBanBody>,
+): Promise<string | null> {
+  if (body.reporterFp) return body.reporterFp.trim();
+  if (!body.githubId) return null;
+  return reporterFingerprint(env, `gh:${body.githubId}`);
+}
+
+app.get("/v1/admin/reporter-bans", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  const rows = await c.env.DB.prepare(
+    `SELECT id, reporter_fp, reason, created_by, created_at, expires_at
+       FROM reporter_bans
+      ORDER BY created_at DESC, id DESC
+      LIMIT 500`,
+  ).all();
+  return c.json({ bans: rows.results ?? [] });
+});
+
+app.post("/v1/admin/reporter-bans", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  let body: z.infer<typeof ReporterBanBody>;
+  try {
+    body = ReporterBanBody.parse(await c.req.json());
+  } catch (err) {
+    return c.json({ error: "bad_request", detail: (err as Error).message }, 400);
+  }
+  const fp = await reporterFpForAdmin(c.env, body);
+  if (!fp) return c.json({ error: "report_salt_required" }, 503);
+  const now = Date.now();
+  const res = await c.env.DB.prepare(
+    `INSERT INTO reporter_bans (reporter_fp, reason, created_by, created_at, expires_at)
+     VALUES (?, ?, 'admin', ?, ?)`,
+  )
+    .bind(fp, body.reason ?? null, now, body.expiresAt ?? null)
+    .run();
+  return c.json({ ok: true, id: res.meta.last_row_id, reporterFp: fp });
+});
+
+app.delete("/v1/admin/reporter-bans/:id", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id)) return c.json({ error: "bad_id" }, 400);
+  const res = await c.env.DB.prepare("DELETE FROM reporter_bans WHERE id=?").bind(id).run();
+  return c.json({ ok: true, deleted: res.meta.changes ?? 0 });
+});
+
+app.post("/v1/admin/reporter-fingerprints/backfill", async (c) => {
+  if (!admin(c)) return c.json({ error: "forbidden" }, 403);
+  if (!c.env.REPORT_SALT?.trim()) return c.json({ error: "report_salt_required" }, 503);
+  const rows = await c.env.DB.prepare(
+    `SELECT reporter_fp AS fp FROM reports WHERE reporter_fp LIKE 'gh:%'
+     UNION
+     SELECT fp FROM rate_log WHERE fp LIKE 'gh:%'
+     UNION
+     SELECT reporter_fp AS fp FROM reporter_bans WHERE reporter_fp LIKE 'gh:%'`,
+  ).all<{ fp: string }>();
+
+  let reports = 0;
+  let rateLog = 0;
+  let bans = 0;
+  for (const row of rows.results ?? []) {
+    const fp = row.fp;
+    const next = await reporterFingerprint(c.env, fp);
+    if (!next || next === fp) continue;
+    const [r1, r2, r3] = await c.env.DB.batch([
+      c.env.DB.prepare("UPDATE reports SET reporter_fp=? WHERE reporter_fp=?").bind(next, fp),
+      c.env.DB.prepare("UPDATE rate_log SET fp=? WHERE fp=?").bind(next, fp),
+      c.env.DB.prepare("UPDATE reporter_bans SET reporter_fp=? WHERE reporter_fp=?").bind(next, fp),
+    ]);
+    reports += r1.meta.changes ?? 0;
+    rateLog += r2.meta.changes ?? 0;
+    bans += r3.meta.changes ?? 0;
+  }
+  return c.json({
+    ok: true,
+    scanned: rows.results?.length ?? 0,
+    updated: { reports, rateLog, bans },
+  });
+});
 
 type AdminSort =
   | "time_desc"

--- a/services/edge/test/edge-reporter-endpoints.test.ts
+++ b/services/edge/test/edge-reporter-endpoints.test.ts
@@ -19,7 +19,7 @@ declare global {
   }
 }
 
-const edgeModuleUrl = new URL("../services/edge/src/index.ts", import.meta.url).href;
+const edgeModuleUrl = new URL("../src/index.ts", import.meta.url).href;
 const worker = (await import(edgeModuleUrl)).default as {
   fetch(req: Request, env: Record<string, unknown>): Promise<Response>;
 };

--- a/services/edge/wrangler.toml
+++ b/services/edge/wrangler.toml
@@ -44,6 +44,7 @@ database_id = "c3a73f50-9af1-4b85-9b5b-db19dd33f175"
 #   npx wrangler secret put ADMIN_TOKEN     # /admin gate
 # Optional:
 #   npx wrangler secret put REQUIRE_AUTH         # "1" => /v1/classify requires GH login
+#   npx wrangler secret put REPORT_SALT          # HMAC salt for reporter fingerprints
 #   npx wrangler secret put WHITELIST_SYNC_TOKEN # fine-grained PAT, Contents:Write on the repo
 #   npx wrangler secret put WHITELIST_SYNC_REPO  # "owner/repo", default foru17/make-x-great-again
 

--- a/test/edge-reporter-endpoints.test.ts
+++ b/test/edge-reporter-endpoints.test.ts
@@ -1,0 +1,418 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+
+declare global {
+  interface D1PreparedStatement {
+    bind(...args: unknown[]): D1PreparedStatement;
+    run(): Promise<{ results?: unknown[]; meta: { changes?: number; last_row_id?: number } }>;
+    first<T>(): Promise<T | null>;
+    all<T>(): Promise<{ results?: T[]; meta?: { changes?: number } }>;
+  }
+
+  interface D1Database {
+    prepare(sql: string): D1PreparedStatement;
+    batch(
+      stmts: D1PreparedStatement[],
+    ): Promise<{ results?: unknown[]; meta: { changes?: number } }[]>;
+    dump(): Promise<Uint8Array>;
+    exec(sql: string): Promise<{ meta: { changes?: number } }>;
+  }
+}
+
+const edgeModuleUrl = new URL("../services/edge/src/index.ts", import.meta.url).href;
+const worker = (await import(edgeModuleUrl)).default as {
+  fetch(req: Request, env: Record<string, unknown>): Promise<Response>;
+};
+
+const originalFetch = globalThis.fetch;
+after(() => {
+  globalThis.fetch = originalFetch;
+});
+
+interface Account {
+  rowid: number;
+  handle: string;
+  x_user_id: string | null;
+  status: string;
+  verdict_label: string;
+  confidence: number;
+}
+
+interface Report {
+  x_user_id: string | null;
+  handle: string;
+  reporter_fp: string;
+  reporter_age_days: number | null;
+  evidence: string;
+  created_at: number;
+}
+
+class MockStmt implements D1PreparedStatement {
+  args: unknown[] = [];
+
+  constructor(
+    private db: MockDB,
+    private sql: string,
+  ) {}
+
+  bind(...args: unknown[]): D1PreparedStatement {
+    this.args = args;
+    return this;
+  }
+
+  async first<T>(): Promise<T | null> {
+    if (this.sql.includes("FROM reporter_bans")) {
+      const [a, b, now] = this.args as [string, string, number];
+      return (
+        (this.db.bans.find(
+          (ban) =>
+            [a, b].includes(ban.reporter_fp) && (ban.expires_at == null || ban.expires_at > now),
+        ) as T | undefined) ?? null
+      );
+    }
+    if (this.sql.includes("FROM rate_log")) {
+      const [a, b, since] = this.args as [string, string, number];
+      const n = this.db.rateLog.filter(
+        (r) => [a, b].includes(r.fp) && r.created_at >= since,
+      ).length;
+      return { n } as T;
+    }
+    if (this.sql.includes("count(DISTINCT CASE")) {
+      const [legacy, canonical, handle, uid, _uid2, minAge] = this.args as [
+        string,
+        string,
+        string,
+        string | null,
+        string | null,
+        number,
+      ];
+      const reporters = new Set<string>();
+      for (const r of this.db.reports) {
+        if (r.handle.toLowerCase() !== handle) continue;
+        if (uid !== null && r.x_user_id !== null && r.x_user_id !== uid) continue;
+        if (r.reporter_age_days !== null && r.reporter_age_days < minAge) continue;
+        reporters.add(r.reporter_fp === legacy ? canonical : r.reporter_fp);
+      }
+      return { n: reporters.size } as T;
+    }
+    if (this.sql.includes("FROM accounts")) {
+      if (this.sql.includes("WHERE x_user_id=?")) {
+        const uid = this.args[0] as string;
+        return (this.db.accounts.find((a) => a.x_user_id === uid) as T | undefined) ?? null;
+      }
+      const handle = this.args[0] as string;
+      const uid = this.args[1] as string | null;
+      return (
+        (this.db.accounts.find(
+          (a) =>
+            a.handle.toLowerCase() === handle &&
+            (uid === null || a.x_user_id === null || a.x_user_id === uid),
+        ) as T | undefined) ?? null
+      );
+    }
+    return null;
+  }
+
+  async all<T>(): Promise<{ results?: T[]; meta?: { changes?: number } }> {
+    if (this.sql.includes("reporter_fp AS fp")) {
+      const fps = new Set<string>();
+      for (const r of this.db.reports) if (r.reporter_fp.startsWith("gh:")) fps.add(r.reporter_fp);
+      for (const r of this.db.rateLog) if (r.fp.startsWith("gh:")) fps.add(r.fp);
+      for (const r of this.db.bans) if (r.reporter_fp.startsWith("gh:")) fps.add(r.reporter_fp);
+      return { results: [...fps].map((fp) => ({ fp })) as T[] };
+    }
+    if (this.sql.includes("FROM reporter_bans")) {
+      return { results: this.db.bans as T[] };
+    }
+    return { results: [] };
+  }
+
+  async run(): Promise<{ results?: unknown[]; meta: { changes?: number; last_row_id?: number } }> {
+    if (this.sql.includes("INSERT INTO reports")) {
+      const [_, uid, handle, fp, age, evidence, now, lookupHandle, a, b] = this.args as [
+        string,
+        string | null,
+        string,
+        string,
+        number,
+        string,
+        number,
+        string,
+        string,
+        string,
+      ];
+      const exists = this.db.reports.some(
+        (r) => r.handle.toLowerCase() === lookupHandle && [a, b].includes(r.reporter_fp),
+      );
+      if (exists) return { meta: { changes: 0 } };
+      this.db.reports.push({
+        x_user_id: uid,
+        handle,
+        reporter_fp: fp,
+        reporter_age_days: age,
+        evidence,
+        created_at: now,
+      });
+      return { meta: { changes: 1 } };
+    }
+    if (this.sql.includes("INSERT INTO rate_log")) {
+      const [fp, createdAt] = this.args as [string, number];
+      this.db.rateLog.push({ fp, created_at: createdAt });
+      return { meta: { changes: 1 } };
+    }
+    if (this.sql.includes("DELETE FROM rate_log")) {
+      const before = this.args[0] as number;
+      const prev = this.db.rateLog.length;
+      this.db.rateLog = this.db.rateLog.filter((r) => r.created_at >= before);
+      return { meta: { changes: prev - this.db.rateLog.length } };
+    }
+    if (this.sql.includes("INSERT INTO review_log")) {
+      this.db.reviewLog.push({ actor: this.args[3] as string, action: this.args[2] as string });
+      return { meta: { changes: 1 } };
+    }
+    if (this.sql.includes("INSERT INTO reporter_bans")) {
+      this.db.bans.push({
+        id: this.db.bans.length + 1,
+        reporter_fp: this.args[0] as string,
+        reason: this.args[1] as string | null,
+        created_by: "admin",
+        created_at: this.args[2] as number,
+        expires_at: this.args[3] as number | null,
+      });
+      return { meta: { changes: 1, last_row_id: this.db.bans.length } };
+    }
+    if (this.sql.includes("DELETE FROM reporter_bans")) {
+      const id = Number(this.args[0]);
+      const prev = this.db.bans.length;
+      this.db.bans = this.db.bans.filter((b) => b.id !== id);
+      return { meta: { changes: prev - this.db.bans.length } };
+    }
+    if (this.sql.includes("UPDATE reports SET reporter_fp")) {
+      const [next, prev] = this.args as [string, string];
+      let changes = 0;
+      for (const r of this.db.reports) {
+        if (r.reporter_fp === prev) {
+          r.reporter_fp = next;
+          changes++;
+        }
+      }
+      return { meta: { changes } };
+    }
+    if (this.sql.includes("UPDATE rate_log SET fp")) {
+      const [next, prev] = this.args as [string, string];
+      let changes = 0;
+      for (const r of this.db.rateLog) {
+        if (r.fp === prev) {
+          r.fp = next;
+          changes++;
+        }
+      }
+      return { meta: { changes } };
+    }
+    if (this.sql.includes("UPDATE reporter_bans SET reporter_fp")) {
+      const [next, prev] = this.args as [string, string];
+      let changes = 0;
+      for (const r of this.db.bans) {
+        if (r.reporter_fp === prev) {
+          r.reporter_fp = next;
+          changes++;
+        }
+      }
+      return { meta: { changes } };
+    }
+    return { meta: { changes: 1 } };
+  }
+}
+
+class MockDB implements D1Database {
+  accounts: Account[] = [
+    {
+      rowid: 1,
+      handle: "target",
+      x_user_id: "100",
+      status: "auto_pending_review",
+      verdict_label: "spam",
+      confidence: 0.95,
+    },
+  ];
+  reports: Report[] = [];
+  rateLog: { fp: string; created_at: number }[] = [];
+  bans: {
+    id: number;
+    reporter_fp: string;
+    reason: string | null;
+    created_by: string;
+    created_at: number;
+    expires_at: number | null;
+  }[] = [];
+  reviewLog: { actor: string; action: string }[] = [];
+
+  prepare(sql: string): D1PreparedStatement {
+    return new MockStmt(this, sql);
+  }
+
+  async batch(
+    stmts: D1PreparedStatement[],
+  ): Promise<{ results?: unknown[]; meta: { changes?: number } }[]> {
+    return Promise.all(stmts.map((stmt) => stmt.run()));
+  }
+
+  async dump(): Promise<Uint8Array> {
+    return new Uint8Array();
+  }
+
+  async exec(): Promise<{ meta: { changes?: number } }> {
+    return { meta: { changes: 0 } };
+  }
+}
+
+function env(db = new MockDB()): Record<string, unknown> {
+  return {
+    DB: db,
+    REPORT_SALT: "test-report-salt",
+    REQUIRE_AUTH: "1",
+    LLM_API_BASE: "https://llm.invalid",
+    LLM_API_KEY: "test",
+    LLM_API_MODEL: "test-model",
+  };
+}
+
+function reportRequest(token = "ok-token"): Request {
+  return new Request("https://x.test/v1/report", {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      userId: "100",
+      handle: "target",
+      displayName: "Target",
+      bio: "full bio should not be stored",
+      recentTweets: ["short public snippet"],
+    }),
+  });
+}
+
+async function reporterFp(raw = "gh:42", salt = "test-report-salt"): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(salt),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const digest = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(raw));
+  const hex = Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+  return `rpt:${hex.slice(0, 32)}`;
+}
+
+globalThis.fetch = async (input: string | URL | Request) => {
+  const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+  if (url === "https://api.github.com/user") {
+    return Response.json({ id: 42, created_at: "2020-01-01T00:00:00Z" });
+  }
+  return originalFetch(input);
+};
+
+test("report endpoint returns 401 without GitHub auth when REQUIRE_AUTH is on", async () => {
+  const db = new MockDB();
+  const res = await worker.fetch(
+    new Request("https://x.test/v1/report", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ userId: "100", handle: "target" }),
+    }),
+    env(db),
+  );
+  assert.equal(res.status, 401);
+  assert.equal(db.reports.length, 0);
+});
+
+test("report endpoint returns 403 for a banned reporter and writes no signal", async () => {
+  const db = new MockDB();
+  db.bans.push({
+    id: 1,
+    reporter_fp: await reporterFp(),
+    reason: "abuse",
+    created_by: "admin",
+    created_at: Date.now(),
+    expires_at: null,
+  });
+  const res = await worker.fetch(reportRequest(), env(db));
+  assert.equal(res.status, 403);
+  assert.equal(db.reports.length, 0);
+  assert.equal(db.rateLog.length, 0);
+});
+
+test("report endpoint returns 429 when reporter is rate-limited and writes no signal", async () => {
+  const db = new MockDB();
+  const fp = await reporterFp();
+  const now = Date.now();
+  for (let i = 0; i < 10; i++) db.rateLog.push({ fp, created_at: now - i * 1000 });
+  const res = await worker.fetch(reportRequest(), env(db));
+  assert.equal(res.status, 429);
+  assert.equal(db.reports.length, 0);
+});
+
+test("report endpoint stores HMAC fingerprint and minimized evidence without raw GitHub id", async () => {
+  const db = new MockDB();
+  const res = await worker.fetch(reportRequest(), env(db));
+  assert.equal(res.status, 200);
+  assert.equal(db.reports.length, 1);
+  const report = db.reports[0];
+  assert.ok(report);
+  assert.match(report.reporter_fp, /^rpt:[0-9a-f]{32}$/);
+  assert.notEqual(report.reporter_fp, "gh:42");
+  assert.ok(!report.evidence.includes("full bio should not be stored"));
+  assert.ok(db.reviewLog[0]?.actor.startsWith("reporter:"));
+  assert.notEqual(db.reviewLog[0]?.actor, "gh:42");
+});
+
+test("legacy gh:<id> report aliases to the HMAC fingerprint and is not double-counted", async () => {
+  const db = new MockDB();
+  db.reports.push({
+    x_user_id: "100",
+    handle: "target",
+    reporter_fp: "gh:42",
+    reporter_age_days: 1000,
+    evidence: "{}",
+    created_at: Date.now() - 10_000,
+  });
+  const res = await worker.fetch(reportRequest(), env(db));
+  const body = (await res.json()) as { duplicate?: boolean; reporters?: number };
+  assert.equal(res.status, 200);
+  assert.equal(body.duplicate, true);
+  assert.equal(body.reporters, 1);
+  assert.equal(db.reports.length, 1);
+});
+
+test("admin backfill migrates legacy report, rate, and ban fingerprints", async () => {
+  const db = new MockDB();
+  db.reports.push({
+    x_user_id: "100",
+    handle: "target",
+    reporter_fp: "gh:42",
+    reporter_age_days: 1000,
+    evidence: "{}",
+    created_at: Date.now(),
+  });
+  db.rateLog.push({ fp: "gh:42", created_at: Date.now() });
+  db.bans.push({
+    id: 1,
+    reporter_fp: "gh:42",
+    reason: "legacy",
+    created_by: "admin",
+    created_at: Date.now(),
+    expires_at: null,
+  });
+  const res = await worker.fetch(
+    new Request("https://x.test/v1/admin/reporter-fingerprints/backfill", {
+      method: "POST",
+      headers: { "x-admin-token": "admin" },
+    }),
+    { ...env(db), ADMIN_TOKEN: "admin" },
+  );
+  assert.equal(res.status, 200);
+  const fp = await reporterFp();
+  assert.equal(db.reports[0]?.reporter_fp, fp);
+  assert.equal(db.rateLog[0]?.fp, fp);
+  assert.equal(db.bans[0]?.reporter_fp, fp);
+});


### PR DESCRIPTION
## 背景

LUO-62 是 T6 moderation rollout 的实现补齐项，承接 LUO-22 as-built 文档中未落地的 reporter identity、rate limit、ban 与 `REQUIRE_AUTH` rollout 准备。

## 本次改动

- Worker 写路径新增 reporter HMAC fingerprint：设置 `REPORT_SALT` 后用服务端 HMAC 派生 `rpt:<hex>`，避免 raw GitHub id 进入 reports / review log / evidence surface。
- `/v1/report` 与 `/v1/confirm` 在写入前执行 reporter ban 与 1h/10 次限流；命中 ban 返回 403，命中限流返回 429，均不写入有效 signal。
- Legacy `gh:<id>` 与新 `rpt:<hex>` 在 dedupe、rate limit、ban 与 independent reporter count 中按同一 reporter 处理，并提供 `/v1/admin/reporter-fingerprints/backfill` 回填接口。
- 新增 `reporter_bans` schema、D1 migration/rollback、admin reporter-ban API，并更新 `.env.example`、`wrangler.toml`、`docs/MODERATION.md`、`docs/MIGRATIONS.md`。
- 新增 edge endpoint tests 覆盖 401/403/429/no-write、HMAC/no raw GH id、legacy alias compatibility 与 backfill；edge CI 独立运行 `npm test`。

## 测试验证

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` (25 tests)
- `cd services/edge && npm run typecheck`
- `cd services/edge && npm test` (6 tests)
- `cd services/edge && npx wrangler deploy --dry-run --outdir /tmp/mxga-edge-luo62-ci-fix-dry-run`
- `cd extension && npm run compile`
- GitHub Actions: core / extension / edge all green on `ec894af`

## 风险与回滚

- 生产启用前需先设置 `REPORT_SALT`，应用 `services/edge/migrations/2026-06-04-reporter-bans.sql`，再调用一次 `/v1/admin/reporter-fingerprints/backfill` 迁移 legacy reporter fingerprints。
- 本 PR 不强行开启 `REQUIRE_AUTH`；owner 可按文档分阶段验证后再切换。
- 如 rollout 出现问题，可回滚 `2026-06-04-reporter-bans.rollback.sql`，并暂不设置或移除 `REQUIRE_AUTH` 保持匿名只读/现有行为。

## 关联 Issue

- [LUO-62](mention://issue/03af7d80-4941-4ab1-b21b-7c1b7879ce9e)
- [LUO-22](mention://issue/74bab631-f52d-4c88-a76a-b6144cd66f86)
