### PR TITLE
Remove explicit 'any' type usage in local-index.ts

### DIFF
--- a/extension/lib/local-index.ts
+++ b/extension/lib/local-index.ts
@@ -31,7 +31,7 @@ export async function warmLocalIndex(): Promise<void> {
         userId,
         handle,
         verdict: {
-          label: label as any,
+          label: label as Verdict['label'],
           confidence,
           reasons,
         },


### PR DESCRIPTION
## Problem
In `extension/lib/local-index.ts`, the `label` property within the `verdict` object was explicitly cast to `any`, which bypasses TypeScript's type safety checks. This can lead to potential runtime errors and reduces code maintainability by allowing any type of data to be assigned.

## Solution
Updated the type assertion from `label as any` to `label as Verdict['label']`, ensuring consistency with the `Verdict` interface defined in the project. This change enhances type safety without altering the external behavior or API of the code.

## Verification
- Run the TypeScript compiler to confirm no type errors are introduced.
- Execute existing unit tests (if available) to ensure the change does not break functionality.
- Manually test the extension by loading it in a browser and verifying that the blacklist index loads correctly and lookup operations (e.g., `lookupByUserId` and `lookupByHandle`) work as expected.