### PR TITLE
fix(edge): exclude invalid identities from published artifacts

### DIFF
--- a/services/edge/src/artifact-identity.ts
+++ b/services/edge/src/artifact-identity.ts
@@ -1,0 +1,11 @@
+const X_HANDLE_RE = /^[A-Za-z0-9_]{1,15}$/;
+const X_USER_ID_RE = /^\d{1,32}$/;
+
+/** The lite artifact is consumed as a strict contract by browser extensions.
+ * Keep legacy/corrupt database rows out instead of publishing one malformed
+ * identity that causes clients to reject the entire snapshot. */
+export function isArtifactIdentityValid(userId: string | null, handle: string): boolean {
+  return (
+    X_HANDLE_RE.test(handle) && (userId === null || userId === "" || X_USER_ID_RE.test(userId))
+  );
+}

--- a/services/edge/src/index.ts
+++ b/services/edge/src/index.ts
@@ -2,6 +2,7 @@ import { type Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import { z } from "zod";
 import { ANALYTICS_CSP, googleAnalyticsHead } from "./analytics";
+import { isArtifactIdentityValid } from "./artifact-identity";
 import { BRAND } from "./brand";
 import { adminHtml } from "./pages/admin";
 import { landingHtml } from "./pages/landing";
@@ -4270,7 +4271,17 @@ async function publishArtifacts(env: Bindings): Promise<void> {
     published_tier: string | null;
   }>();
 
-  const accounts = rows.results ?? [];
+  const rawAccounts = rows.results ?? [];
+  const accounts = rawAccounts.filter((account) =>
+    isArtifactIdentityValid(account.x_user_id, account.handle),
+  );
+  const droppedInvalidIdentities = rawAccounts.length - accounts.length;
+  if (droppedInvalidIdentities > 0) {
+    logWarn("artifact_invalid_identities_dropped", {
+      dropped: droppedInvalidIdentities,
+      total: rawAccounts.length,
+    });
+  }
   // NULL tier = written between the migration and this deploy; treat as
   // 'auto' (fail-safe: never auto-block an entry of unknown provenance).
   const tierCode = (t: string | null) => (t === "human" ? "h" : "a");

--- a/services/edge/test/artifact-identity.test.ts
+++ b/services/edge/test/artifact-identity.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isArtifactIdentityValid } from "../src/artifact-identity";
+
+test("accepts identities representable in the lite artifact", () => {
+  assert.equal(isArtifactIdentityValid("2077936309436637687", "tualatrix"), true);
+  assert.equal(isArtifactIdentityValid(null, "handle_only"), true);
+  assert.equal(isArtifactIdentityValid("", "legacy_empty_id"), true);
+  assert.equal(isArtifactIdentityValid("123", "fifteen_chars_1"), true);
+});
+
+test("rejects malformed handles before artifact publication", () => {
+  assert.equal(isArtifactIdentityValid(null, "christo59389780  @christo59389780"), false);
+  assert.equal(isArtifactIdentityValid(null, "test_xss_migration_dummy"), false);
+  assert.equal(isArtifactIdentityValid("123", "@leading_at"), false);
+  assert.equal(isArtifactIdentityValid("123", "bad-hyphen"), false);
+  assert.equal(isArtifactIdentityValid("123", ""), false);
+});
+
+test("rejects malformed numeric user ids", () => {
+  assert.equal(isArtifactIdentityValid("not-numeric", "valid_handle"), false);
+  assert.equal(isArtifactIdentityValid("1".repeat(33), "valid_handle"), false);
+});


### PR DESCRIPTION
## Problem

The extension's **Update now** action can fail with `invalid entry row`, leaving the downloaded blacklist and rules unavailable:

![MXGA management panel showing “更新失败：invalid entry row”](https://raw.githubusercontent.com/tualatrix/make-x-great-again/pr-assets-invalid-entry-row/mxga-invalid-entry-row.png)

The live lite artifact inspected while reproducing this contained 134,257 rows, including three identities that cannot represent an X account:

- two legacy handle-only rows containing whitespace, display text, and a second `@handle`;
- one migration/test handle longer than X's 15-character limit.

The extension is intentionally strict when validating a remote artifact. A single malformed row therefore rejects the complete snapshot rather than partially trusting an unexpected payload. That behavior is useful defense-in-depth; the producer should not emit malformed identities in the first place.

## Root cause

`publishArtifacts()` selected every `human_confirmed` database row and serialized `handle` / `x_user_id` directly into the bloom, shard, and lite artifacts. Current API write paths validate handles, but legacy imports and migration rows can predate those checks.

## Fix

- Validate stored identities at the artifact boundary:
  - handle must match `[A-Za-z0-9_]{1,15}`;
  - user ID may be null/empty, otherwise it must contain 1–32 digits.
- Filter the account set **once before generating any artifact**, keeping bloom, shards, lite output, version counts, and metadata consistent.
- Emit a structured warning with the dropped and total row counts so legacy data remains observable without breaking clients.
- Keep the database rows untouched for audit/admin cleanup; only invalid public output is suppressed.

This is preferable to loosening client validation globally: malformed server data no longer reaches any consumer, while clients can retain strict integrity checks.

## Verification

- `npm --prefix services/edge test` — 46 tests passed.
- `npm --prefix services/edge run typecheck` — passed.
- Replayed the current live artifact through the new identity guard: 134,254 rows accepted, exactly 3 malformed rows excluded.
