### PR TITLE
feat(extension): setting to disable auto-expanding the bubble card during auto-processing

### DIFF
--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -197,6 +197,7 @@ export default defineContentScript({
       // Keep the bubble's 自动处理 switch + hint in sync (options page or
       // another tab may have flipped it).
       bubbleApi?.setAutoProcess(s.autoProcess, autoCategoryCount(s), s.autoScope === "all");
+      bubbleApi?.setAutoExpand(s.autoExpand);
     });
 
     // Warm local data structures
@@ -807,6 +808,7 @@ export default defineContentScript({
           autoProcess: settings.autoProcess,
           autoCategoryCount: autoCategoryCount(settings),
           autoScopeAll: settings.autoScope === "all",
+          autoExpand: settings.autoExpand,
         });
         container.appendChild(bubble.el);
         if (!settings.bubble) bubble.el.style.display = "none";

--- a/extension/entrypoints/options/App.tsx
+++ b/extension/entrypoints/options/App.tsx
@@ -1304,6 +1304,12 @@ function Settings() {
               label="气泡位置：右上角"
               hint="关 = 右下角"
             />
+            <Toggle
+              on={st.autoExpand}
+              onChange={(v) => save("autoExpand", v)}
+              label="自动处理时展开面板"
+              hint="关闭后仅气泡脉冲提示，不弹出处理卡片（小屏 / 手机端建议关闭）"
+            />
           </section>
         )}
 

--- a/extension/lib/settings.ts
+++ b/extension/lib/settings.ts
@@ -38,6 +38,7 @@ export interface Settings {
   categoryActions: CategoryActions; // per-category automatic action on list hits
   autoProcess: boolean; // master kill-switch for categoryActions auto hide/mute/block
   autoScope: AutoScope; // where auto actions may fire (replies-only by default)
+  autoExpand: boolean; // pop the bubble card open when auto-processing starts (off = pill pulse only; better on narrow/mobile viewports)
   edgeBase: string; // advanced: override the public-list site base URL (links only)
 }
 
@@ -60,6 +61,7 @@ export const DEFAULTS: Settings = {
   categoryActions: { ...DEFAULT_CATEGORY_ACTIONS },
   autoProcess: true,
   autoScope: "replies",
+  autoExpand: true,
   edgeBase: "",
 };
 

--- a/extension/lib/ui.ts
+++ b/extension/lib/ui.ts
@@ -575,6 +575,9 @@ export interface BubbleOpts {
   /** true = auto actions fire everywhere (settings.autoScope === "all");
    *  false = replies-only (default scope). */
   autoScopeAll?: boolean;
+  /** Pop the card open when the auto queue starts (settings.autoExpand).
+   *  false = stay collapsed; the pill's hit-pulse is the only signal. */
+  autoExpand?: boolean;
 }
 
 /** Collapsed pill ⇄ expanded card. Default resting state = pill.
@@ -1299,6 +1302,7 @@ export function createBubble(
   // page (reset on SPA navigation).
   let autoOpened = false;
   let userClosed = false;
+  let autoExpand = opts.autoExpand !== false;
   let collapseTimer: ReturnType<typeof setTimeout> | undefined;
   function collapseByUser() {
     userClosed = true;
@@ -1446,7 +1450,7 @@ export function createBubble(
       rowState.set(key, st);
       bump(key); // every auto transition leads the feed
       clearTimeout(collapseTimer); // fresh activity holds the card open
-      if ((st === "queued" || st === "processing") && !open && !userClosed) {
+      if ((st === "queued" || st === "processing") && autoExpand && !open && !userClosed) {
         // Show the work as it happens — pop the card open the moment the
         // auto queue starts building; it folds back once the batch settles.
         autoOpened = true;
@@ -1465,6 +1469,11 @@ export function createBubble(
       if (categoryCount !== undefined) autoCats = categoryCount;
       if (scopeAll !== undefined) autoScopeAll = scopeAll;
       if (open) renderCard();
+    },
+    /** Live-sync settings.autoExpand (options page or another tab). Only
+     *  affects future auto-opens; an already-open card is left alone. */
+    setAutoExpand(v: boolean) {
+      autoExpand = v;
     },
   };
 }


### PR DESCRIPTION
## Why

When auto-processing kicks in, the bubble card pops open unconditionally. Fine on desktop, but on narrow/mobile viewports the card covers the timeline.

## What

- New `settings.autoExpand` (default **true** — shipped behavior unchanged).
- Off → the auto queue leaves the bubble collapsed; the pill's hit-pulse remains the only signal. Manual open/close and the first-run intro are untouched.
- Live-synced across tabs/options via `onSettingsChange`, same as the other bubble options.
- Options page: new toggle under 检测行为 (自动处理时展开面板), with a hint recommending mobile users switch it off.

## Verification

- `tsc --noEmit` clean, 14 extension tests pass, `wxt build` OK.
- Options page UI checked desktop light/dark + 390px mobile viewport; toggle flips `aria-checked` and persists through the same `save()` path as neighboring toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYznitggbd4bW1Zsedvciy