### PR TITLE
perf(extension): 自动本地隐藏改为批量执行

### DIFF
--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -1,6 +1,11 @@
 import { hideAccountSurface } from "../lib/account-surface";
 import { autoEligible, capAutoTierAction } from "../lib/auto-policy";
-import { addBlocked, isBlockedSync, warm as warmBlocklist } from "../lib/blocklist";
+import {
+  addBlocked,
+  addBlockedMany,
+  isBlockedSync,
+  warm as warmBlocklist,
+} from "../lib/blocklist";
 import { BRAND } from "../lib/brand";
 import { type Cached, cacheGet, signalsHash } from "../lib/cache";
 import {
@@ -21,10 +26,12 @@ import {
   onSettingsChange,
   setSetting,
 } from "../lib/settings";
-import { bumpStat } from "../lib/stats";
+import { bumpStat, bumpStatBy } from "../lib/stats";
 import {
+  type BlockRecord,
   type PendingXAction,
   addBlockRecord,
+  addBlockRecords,
   addPendingAction,
   bumpStats,
   clearPendingAction,
@@ -421,12 +428,9 @@ export default defineContentScript({
     }
 
     // ---- Visible auto-processing queue (the v0.4 爽感 path) ----
-    // Auto hits do NOT vanish silently: each account is queued and worked
-    // ONE AT A TIME — in-place pulsing "拉黑中" badge on the tweet, live
-    // queued→processing→done row states in the bubble (which auto-opens),
-    // then an animated collapse of the cell. The decision itself is recorded
-    // up-front, so only the theater is deferred, never the protection.
-    const AUTO_MIN_ACT_MS = 900; // every item is visibly "worked" this long
+    // Auto hits do NOT vanish silently. Local hides settle as one gathered
+    // batch; X mute/block actions keep the visible one-at-a-time queue.
+    const AUTO_MIN_ACT_MS = 900; // every X action is visibly "worked" this long
     const AUTO_SETTLE_MS = 240; // beat between items (v0.4: 180ms)
     // Roster-first: the page scan surfaces hits one by one, so the sweep
     // waits out a short gather window — the bubble fills with 排队中 rows
@@ -444,6 +448,7 @@ export default defineContentScript({
       verdict: Verdict;
       categoryZh: string;
       tweetId?: string;
+      record: BlockRecord;
     }
     const autoQueue: AutoItem[] = [];
     // Keys owned by the queue — step 0's insta-hide must spare the cell the
@@ -468,45 +473,27 @@ export default defineContentScript({
       );
     }
 
-    function enqueueAuto(it: AutoItem) {
-      if (autoActing.has(it.key)) return;
-      autoActing.add(it.key);
-      // Record FIRST — the protection survives navigation even if the
-      // animation never gets to play.
-      void addBlocked(it.key);
-      if (it.sig.userId) void addBlocked(it.sig.userId);
-      // The 处理记录 row too: the id lands in xss:blocked above, and a record
-      // is the only UI path back (恢复显示). Writing it after the paced X
-      // action left a window (tab close mid-queue) that produced permanently
-      // hidden accounts with no recover entry. The X-failure annotation is
-      // patched in later by the drain loop.
-      const tweetText = it.sig.triggeringComment || it.sig.recentTweets[0];
-      void addBlockRecord({
-        id: it.key,
-        handle: it.sig.handle,
-        ...(it.sig.displayName ? { displayName: it.sig.displayName } : {}),
-        ...(it.sig.avatarUrl ? { avatarUrl: it.sig.avatarUrl } : {}),
-        ...(it.tweetId ? { tweetId: it.tweetId } : {}),
-        ...(tweetText ? { tweetText } : {}),
-        verdict: it.verdict,
-        reason: `${it.categoryZh} · 自动${it.verb}`,
-        source: "auto",
-        ts: Date.now(),
-      });
-      // Track the not-yet-fired X action separately (see PendingXAction): a
-      // mid-queue reload can then tell a queued account apart from a completed
-      // one — resuming it instead of falsely counting it as 已处理. Local-only
-      // hides need no X call, so nothing to track.
-      if (it.action === "mute" || it.action === "block") {
-        void addPendingAction({
-          id: it.key,
-          handle: it.sig.handle,
-          action: it.action,
+    function enqueueAuto(item: Omit<AutoItem, "record">) {
+      if (autoActing.has(item.key)) return;
+      autoActing.add(item.key);
+      // Snapshot the audit row at enqueue time (especially ts/tweet text),
+      // then commit it at the front of the drain iteration before any action.
+      const tweetText = item.sig.triggeringComment || item.sig.recentTweets[0];
+      const it: AutoItem = {
+        ...item,
+        record: {
+          id: item.key,
+          handle: item.sig.handle,
+          ...(item.sig.displayName ? { displayName: item.sig.displayName } : {}),
+          ...(item.sig.avatarUrl ? { avatarUrl: item.sig.avatarUrl } : {}),
+          ...(item.tweetId ? { tweetId: item.tweetId } : {}),
+          ...(tweetText ? { tweetText } : {}),
+          verdict: item.verdict,
+          reason: `${item.categoryZh} · 自动${item.verb}`,
+          source: "auto",
           ts: Date.now(),
-        });
-      }
-      void bumpStats({ blocks: 1 });
-      void bumpStat("blocked");
+        },
+      };
       anchorByKey.set(it.key, it.anchor);
       articleOf(it.anchor)?.setAttribute("data-xss-key", it.key);
       mountActing(it.anchor, it.verb, true);
@@ -547,22 +534,83 @@ export default defineContentScript({
 
     async function drainAutoLoop() {
       while (autoQueue.length) {
+        const localBatch: AutoItem[] = [];
+        for (let i = 0; i < autoQueue.length; ) {
+          const queued = autoQueue[i];
+          if (queued && queued.action !== "mute" && queued.action !== "block") {
+            localBatch.push(...autoQueue.splice(i, 1));
+          } else {
+            i++;
+          }
+        }
+
+        if (localBatch.length) {
+          const keys = localBatch.map((item) => item.key);
+          let recordsCommitted = true;
+          try {
+            await addBlockRecords(localBatch.map((item) => item.record));
+          } catch (e) {
+            recordsCommitted = false;
+            console.warn("[MXGA] 自动隐藏：处理记录批量写入失败", e);
+          }
+
+          if (recordsCommitted) {
+            try {
+              await addBlockedMany(
+                localBatch.flatMap((item) =>
+                  item.sig.userId ? [item.key, item.sig.userId] : [item.key],
+                ),
+              );
+              await Promise.all([
+                bumpStats({ blocks: localBatch.length }),
+                bumpStatBy("blocked", localBatch.length),
+              ]);
+            } catch (e) {
+              console.warn("[MXGA] 自动隐藏：屏蔽 ID 批量写入失败", e);
+            }
+          }
+
+          for (const item of localBatch) {
+            try {
+              hideAccountSurface(autoTarget(item));
+            } catch (e) {
+              console.warn("[MXGA] 自动隐藏 DOM 处理异常", item.sig.handle, e);
+            } finally {
+              autoActing.delete(item.key);
+            }
+          }
+          try {
+            bubbleApi?.markAutoBatchDone(keys, "隐藏");
+          } catch (e) {
+            console.warn("[MXGA] 自动隐藏批量反馈异常", e);
+          }
+          continue;
+        }
+
         const it = autoQueue.shift();
         if (!it) break;
         // One broken item (dead DOM node, render error) must not strand the
         // rest of the queue — fail it and move on.
         try {
+          // Commit in recoverable order before firing the irreversible X
+          // action: audit record → fast-path id set → resume marker.
+          await addBlockRecords([it.record]);
+          await addBlockedMany(it.sig.userId ? [it.key, it.sig.userId] : [it.key]);
+          await addPendingAction({
+            id: it.key,
+            handle: it.sig.handle,
+            action: it.action as "mute" | "block",
+            ts: Date.now(),
+          });
+          await Promise.all([bumpStats({ blocks: 1 }), bumpStatBy("blocked", 1)]);
+
           const t0 = Date.now();
           const acting = autoTarget(it);
           if (acting) mountActing(acting, it.verb, false);
           bubbleApi?.markAuto(it.key, "processing", it.verb);
-          const xOk =
-            it.action === "mute" || it.action === "block"
-              ? await applyXAction(it.action, it.sig)
-              : true;
+          const xOk = await applyXAction(it.action as "mute" | "block", it.sig);
           if (!xOk)
             console.warn(`[MXGA] 自动${it.verb}：X 原生动作失败`, it.sig.handle, it.sig.userId);
-          // Even the instant local-hide mode dwells long enough to be SEEN.
           const dwell = AUTO_MIN_ACT_MS - (Date.now() - t0);
           if (dwell > 0) await sleep(dwell);
           // Hide the real tweet INSTANTLY — the processing theater (fade /
@@ -573,13 +621,11 @@ export default defineContentScript({
           // The action has now SETTLED (attempted) — drop its pending marker so
           // it stops being a resume candidate; only items whose queue died
           // before this point stay pending. On X failure, annotate the record.
-          if (it.action === "mute" || it.action === "block") {
-            void clearPendingAction(it.key);
-            if (!xOk) {
-              void updateBlockRecord(it.key, {
-                reason: `${it.categoryZh} · 自动${it.verb}（X 动作失败，仅本地隐藏）`,
-              });
-            }
+          void clearPendingAction(it.key);
+          if (!xOk) {
+            void updateBlockRecord(it.key, {
+              reason: `${it.categoryZh} · 自动${it.verb}（X 动作失败，仅本地隐藏）`,
+            });
           }
           bubbleApi?.markAuto(it.key, xOk ? "done" : "failed", it.verb);
         } catch (e) {
@@ -765,10 +811,8 @@ export default defineContentScript({
         ...(badgeSource === "list" ? { tier: entry.tier } : {}),
       });
       const verb = action === "mute" ? "静音" : action === "block" ? "拉黑" : "隐藏";
-      // The visible queue owns everything from here: records up-front, then
-      // in-place badge → paced X action → animated collapse → bubble row
-      // states. The 处理记录 line is written after the X action settles so it
-      // can state honestly whether the native mute/block actually landed.
+      // The visible queue owns everything from here: local actions settle as
+      // one batch; X actions retain their in-place badge and paced sequence.
       enqueueAuto({
         key,
         sig,

--- a/extension/lib/blocklist.ts
+++ b/extension/lib/blocklist.ts
@@ -4,6 +4,27 @@
 const KEY = "xss:blocked";
 
 let mem: Set<string> | null = null;
+const optimisticAdds = new Set<string>();
+
+type LockCapableNavigator = Navigator & {
+  locks?: {
+    request<T>(name: string, callback: () => T | Promise<T>): Promise<T>;
+  };
+};
+
+const lockChains = new Map<string, Promise<unknown>>();
+async function withKeyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const locks =
+    typeof navigator === "undefined"
+      ? undefined
+      : (navigator as LockCapableNavigator).locks;
+  if (locks) return locks.request(`mxga-store:${key}`, fn);
+
+  const previous = lockChains.get(key) ?? Promise.resolve();
+  const run = previous.then(fn, fn);
+  lockChains.set(key, run.catch(() => {}));
+  return run;
+}
 
 // Keep the in-memory set in sync across contexts: when the options page
 // un-hides an account (or another tab hides one), every open X tab must see
@@ -12,6 +33,7 @@ try {
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === "local" && changes[KEY]) {
       mem = new Set<string>((changes[KEY]?.newValue as string[]) ?? []);
+      for (const id of optimisticAdds) mem.add(id);
     }
   });
 } catch {
@@ -43,21 +65,50 @@ export async function warm(): Promise<void> {
 }
 
 export async function addBlocked(id: string): Promise<void> {
-  const s = await load();
-  if (s.has(id)) return;
-  s.add(id);
   try {
-    await chrome.storage.local.set({ [KEY]: [...s] });
+    await addBlockedMany([id]);
   } catch {
-    /* non-fatal */
+    /* non-fatal for legacy single-id callers */
+  }
+}
+
+export async function addBlockedMany(ids: string[]): Promise<void> {
+  const unique = [...new Set(ids)];
+  if (!unique.length) return;
+
+  // Keep the synchronous fast path optimistic: callers often intentionally
+  // do not await persistence, while process() immediately checks this set.
+  if (!mem) mem = new Set();
+  for (const id of unique) {
+    optimisticAdds.add(id);
+    mem.add(id);
+  }
+
+  try {
+    await withKeyLock(KEY, async () => {
+      const got = await chrome.storage.local.get(KEY);
+      const authoritative = new Set<string>((got[KEY] as string[]) ?? []);
+      for (const id of unique) authoritative.add(id);
+      await chrome.storage.local.set({ [KEY]: [...authoritative] });
+      mem = new Set([...authoritative, ...optimisticAdds]);
+    });
+  } finally {
+    for (const id of unique) optimisticAdds.delete(id);
   }
 }
 
 export async function removeBlocked(id: string): Promise<void> {
-  const s = await load();
-  if (!s.delete(id)) return;
   try {
-    await chrome.storage.local.set({ [KEY]: [...s] });
+    await withKeyLock(KEY, async () => {
+      const got = await chrome.storage.local.get(KEY);
+      const authoritative = new Set<string>((got[KEY] as string[]) ?? []);
+      if (!authoritative.delete(id)) {
+        mem = authoritative;
+        return;
+      }
+      await chrome.storage.local.set({ [KEY]: [...authoritative] });
+      mem = authoritative;
+    });
   } catch {
     /* non-fatal */
   }

--- a/extension/lib/stats.ts
+++ b/extension/lib/stats.ts
@@ -6,6 +6,8 @@
 //   - lookup hit → "命中本地名单（零成本）"
 //   - hide       → "你亲手隐藏了一个"
 
+import { withKeyLock } from "./store";
+
 export interface LocalStats {
   /** Legacy counter from the AI era — kept for storage compatibility. */
   scanned: number;
@@ -37,11 +39,13 @@ export async function bumpStatBy(
   key: keyof Omit<LocalStats, "firstUsedAt">,
   n = 1,
 ): Promise<void> {
-  const cur = await getStats();
-  cur[key] = (cur[key] ?? 0) + Math.max(0, Math.floor(n));
-  // Set firstUsedAt the first time we bump anything from a fresh install.
-  if (!cur.firstUsedAt) cur.firstUsedAt = Date.now();
-  await new Promise<void>((r) => chrome.storage.local.set({ [KEY]: cur }, () => r()));
+  await withKeyLock(KEY, async () => {
+    const cur = await getStats();
+    cur[key] = (cur[key] ?? 0) + Math.max(0, Math.floor(n));
+    // Set firstUsedAt the first time we bump anything from a fresh install.
+    if (!cur.firstUsedAt) cur.firstUsedAt = Date.now();
+    await new Promise<void>((r) => chrome.storage.local.set({ [KEY]: cur }, () => r()));
+  });
 }
 
 export async function bumpStat(key: keyof Omit<LocalStats, "firstUsedAt">): Promise<void> {

--- a/extension/lib/store.ts
+++ b/extension/lib/store.ts
@@ -62,6 +62,30 @@ const K_BLOCK_LEGACY = "xss:blocked";
 const K_STATS = "xss:stats";
 const K_PENDING = "xss:pending-actions";
 
+type LockCapableNavigator = Navigator & {
+  locks?: {
+    request<T>(name: string, callback: () => T | Promise<T>): Promise<T>;
+  };
+};
+
+const lockChains = new Map<string, Promise<unknown>>();
+
+/** Serialize storage RMW operations for this key. Web Locks cover tabs that
+ * share the same origin/storage bucket only; an X content script does not
+ * share its LockManager with the extension options page or another origin. */
+export async function withKeyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const locks =
+    typeof navigator === "undefined"
+      ? undefined
+      : (navigator as LockCapableNavigator).locks;
+  if (locks) return locks.request(`mxga-store:${key}`, fn);
+
+  const previous = lockChains.get(key) ?? Promise.resolve();
+  const run = previous.then(fn, fn);
+  lockChains.set(key, run.catch(() => {}));
+  return run;
+}
+
 async function get<T>(key: string, fallback: T): Promise<T> {
   try {
     const g = await chrome.storage.local.get(key);
@@ -76,6 +100,15 @@ async function set(key: string, val: unknown): Promise<void> {
   } catch {
     /* non-fatal */
   }
+}
+
+async function getStrict<T>(key: string, fallback: T): Promise<T> {
+  const stored = await chrome.storage.local.get(key);
+  return (stored[key] as T) ?? fallback;
+}
+
+async function setStrict(key: string, val: unknown): Promise<void> {
+  await chrome.storage.local.set({ [key]: val });
 }
 
 export async function getBlocklist(): Promise<BlockRecord[]> {
@@ -93,40 +126,67 @@ export async function getBlocklist(): Promise<BlockRecord[]> {
   return migrated;
 }
 
+export async function addBlockRecords(recs: BlockRecord[]): Promise<void> {
+  if (!recs.length) return;
+  await withKeyLock(K_BLOCK, async () => {
+    const v2 = await getStrict<BlockRecord[] | null>(K_BLOCK, null);
+    let migrated = false;
+    let list: BlockRecord[];
+    if (v2) {
+      list = v2;
+    } else {
+      const legacy = await getStrict<string[]>(K_BLOCK_LEGACY, []);
+      list = legacy.map((id) => ({
+        id,
+        handle: id.startsWith("h:") ? id.slice(2) : id,
+        source: "manual",
+        ts: Date.now(),
+      }));
+      migrated = list.length > 0;
+    }
+
+    const ids = new Set(list.map((record) => record.id));
+    let added = false;
+    for (const rec of recs) {
+      if (ids.has(rec.id)) continue;
+      ids.add(rec.id);
+      list.push(rec);
+      added = true;
+    }
+    if (added || migrated) await setStrict(K_BLOCK, list);
+  });
+}
+
 export async function addBlockRecord(rec: BlockRecord): Promise<void> {
-  const list = await getBlocklist();
-  if (list.some((r) => r.id === rec.id)) return;
-  list.push(rec);
-  await set(K_BLOCK, list);
+  try {
+    await addBlockRecords([rec]);
+  } catch {
+    /* non-fatal for legacy single-record callers */
+  }
 }
 
 export async function updateBlockRecord(
   id: string,
   patch: Partial<Omit<BlockRecord, "id">>,
 ): Promise<void> {
-  const list = await getBlocklist();
-  const i = list.findIndex((r) => r.id === id);
-  const rec = list[i];
-  if (!rec) return;
-  const merged: BlockRecord = { ...rec, ...patch };
-  // A patch value of undefined means "clear this field" (e.g. settling
-  // pendingAction) — drop the key rather than persisting an undefined.
-  for (const k of Object.keys(patch) as (keyof typeof patch)[]) {
-    if (patch[k] === undefined) delete merged[k];
-  }
-  list[i] = merged;
-  await set(K_BLOCK, list);
+  await withKeyLock(K_BLOCK, async () => {
+    const list = await getBlocklist();
+    const i = list.findIndex((r) => r.id === id);
+    const rec = list[i];
+    if (!rec) return;
+    const merged: BlockRecord = { ...rec, ...patch };
+    // A patch value of undefined means "clear this field" (e.g. settling
+    // pendingAction) — drop the key rather than persisting an undefined.
+    for (const k of Object.keys(patch) as (keyof typeof patch)[]) {
+      if (patch[k] === undefined) delete merged[k];
+    }
+    list[i] = merged;
+    await set(K_BLOCK, list);
+  });
 }
 
-// Serialize read-modify-write on the pending-actions key. A page can enqueue
-// many auto-actions in one scan tick; unserialized void writes would race on
-// getPending→set and drop entries (a dropped entry = an account wrongly shown
-// as done instead of resumed). One in-context chain keeps them consistent.
-let pendingLock: Promise<unknown> = Promise.resolve();
 function withPendingLock<T>(fn: () => Promise<T>): Promise<T> {
-  const run = pendingLock.then(fn, fn);
-  pendingLock = run.catch(() => {});
-  return run;
+  return withKeyLock(K_PENDING, fn);
 }
 
 export async function getPendingActions(): Promise<PendingXAction[]> {
@@ -153,13 +213,16 @@ export async function clearPendingAction(id: string): Promise<void> {
 }
 
 export async function removeBlock(id: string): Promise<void> {
-  const list = await getBlocklist();
-  await set(
-    K_BLOCK,
-    list.filter((r) => r.id !== id),
-  );
+  await withKeyLock(K_BLOCK, async () => {
+    const list = await getBlocklist();
+    await set(
+      K_BLOCK,
+      list.filter((r) => r.id !== id),
+    );
+  });
   // Also reconcile the fast-path id set (xss:blocked) that content.ts hides
-  // by — otherwise un-hiding never takes effect on X pages.
+  // by — otherwise un-hiding never takes effect on X pages. Acquire its lock
+  // only after releasing K_BLOCK so the two independent locks cannot deadlock.
   await removeBlocked(id);
 }
 
@@ -177,12 +240,14 @@ export async function getStats(): Promise<Stats> {
 }
 
 export async function bumpStats(patch: Partial<Stats> & { label?: string }): Promise<void> {
-  const s = await getStats();
-  s.detections += patch.detections ?? 0;
-  s.cacheHits += patch.cacheHits ?? 0;
-  s.blocks += patch.blocks ?? 0;
-  if (patch.label) s.byLabel[patch.label] = (s.byLabel[patch.label] ?? 0) + 1;
-  await set(K_STATS, s);
+  await withKeyLock(K_STATS, async () => {
+    const s = await getStats();
+    s.detections += patch.detections ?? 0;
+    s.cacheHits += patch.cacheHits ?? 0;
+    s.blocks += patch.blocks ?? 0;
+    if (patch.label) s.byLabel[patch.label] = (s.byLabel[patch.label] ?? 0) + 1;
+    await set(K_STATS, s);
+  });
 }
 
 /** Clear all local extension data (privacy). */

--- a/extension/lib/ui.ts
+++ b/extension/lib/ui.ts
@@ -1572,6 +1572,36 @@ export function createBubble(
       if (st === "done") scheduleAbsorb(key); // linger, then fly into the chip
       if (autoOpened && open && stats().running === 0) scheduleAutoCollapse();
     },
+    /** AUTO local-hide path: settle a gathered batch in one render and one
+     * flock animation instead of scheduling N serial solo flights. */
+    markAutoBatchDone(keys: string[], verbLabel: string) {
+      if (!keys.length) return;
+      clearTimeout(collapseTimer);
+      // Match startBatch: keep the batch's first key highest in the feed.
+      for (const key of [...keys].reverse()) bump(key);
+      for (const key of keys) {
+        autoRows.add(key);
+        autoVerbs.set(key, verbLabel);
+        rowState.set(key, "done");
+        const existing = absorbTimers.get(key);
+        if (existing) clearTimeout(existing);
+        absorbTimers.delete(key);
+      }
+      renderPill();
+      if (open) renderCard();
+
+      const timerKey = keys[0];
+      if (timerKey) {
+        absorbTimers.set(
+          timerKey,
+          setTimeout(() => {
+            absorbTimers.delete(timerKey);
+            void flyKeys([...keys]);
+          }, DONE_LINGER_MS),
+        );
+      }
+      if (autoOpened && open && stats().running === 0) scheduleAutoCollapse();
+    },
     /** Manual popover hide of a listed account: drive the live bubble row to
      *  "done" so it stops showing an actionable 隐藏 button (the tweet is
      *  already gone) and joins the 已处理 record — matching the auto path.

--- a/extension/test/store-batch.test.ts
+++ b/extension/test/store-batch.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { LocalStats } from "../lib/stats";
+import type { BlockRecord, Stats } from "../lib/store";
+
+type StorageData = Record<string, unknown>;
+type ChangeListener = (
+  changes: Record<string, { oldValue?: unknown; newValue?: unknown }>,
+  area: string,
+) => void;
+
+const data: StorageData = {};
+const setCalls = new Map<string, number>();
+const changeListeners: ChangeListener[] = [];
+let failingSetKey: string | null = null;
+
+const clone = <T>(value: T): T => structuredClone(value);
+const later = <T>(value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), 2));
+
+function select(keys: unknown): StorageData {
+  if (keys === null) return clone(data);
+  const names =
+    typeof keys === "string"
+      ? [keys]
+      : Array.isArray(keys)
+        ? keys
+        : Object.keys((keys as StorageData | undefined) ?? {});
+  return Object.fromEntries(
+    names.filter((key) => key in data).map((key) => [key, clone(data[key])]),
+  );
+}
+
+function reset(next: StorageData = {}) {
+  for (const key of Object.keys(data)) delete data[key];
+  Object.assign(data, clone(next));
+  setCalls.clear();
+  failingSetKey = null;
+}
+
+const chromeStub = {
+  storage: {
+    local: {
+      get(keys: unknown, callback?: (got: StorageData) => void) {
+        const snapshot = select(keys);
+        if (callback) {
+          setTimeout(() => callback(snapshot), 2);
+          return;
+        }
+        return later(snapshot);
+      },
+      set(items: StorageData, callback?: () => void) {
+        const snapshot = clone(items);
+        const commit = async () => {
+          await later(undefined);
+          const keys = Object.keys(snapshot);
+          if (keys.some((key) => key === failingSetKey)) {
+            throw new Error(`set failed: ${failingSetKey}`);
+          }
+          const changes: Record<string, { oldValue?: unknown; newValue?: unknown }> = {};
+          for (const key of keys) {
+            changes[key] = { oldValue: clone(data[key]), newValue: clone(snapshot[key]) };
+            data[key] = clone(snapshot[key]);
+            setCalls.set(key, (setCalls.get(key) ?? 0) + 1);
+          }
+          for (const listener of changeListeners) listener(changes, "local");
+        };
+        if (callback) {
+          void commit().then(callback);
+          return;
+        }
+        return commit();
+      },
+    },
+    onChanged: {
+      addListener(listener: ChangeListener) {
+        changeListeners.push(listener);
+      },
+    },
+  },
+};
+
+class FakeLockManager {
+  requests = 0;
+  private chains = new Map<string, Promise<unknown>>();
+
+  request<T>(name: string, callback: () => T | Promise<T>): Promise<T> {
+    this.requests++;
+    const previous = this.chains.get(name) ?? Promise.resolve();
+    const run = previous.then(callback, callback);
+    this.chains.set(name, run.catch(() => {}));
+    return run;
+  }
+}
+
+const root = globalThis as unknown as { chrome?: unknown };
+const previousChrome = root.chrome;
+const previousNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+root.chrome = chromeStub;
+
+const store = await import("../lib/store");
+const blocklist = await import("../lib/blocklist");
+const localStats = await import("../lib/stats");
+
+const record = (id: string): BlockRecord => ({
+  id,
+  handle: `user-${id}`,
+  source: "auto",
+  ts: 1,
+});
+
+function setNavigator(locks?: FakeLockManager) {
+  Object.defineProperty(globalThis, "navigator", {
+    value: locks ? { locks } : {},
+    configurable: true,
+    writable: true,
+  });
+}
+
+test("storage batches and RMW locks", async (t) => {
+  try {
+    await t.test("addBlockRecords writes one deduplicated batch", async () => {
+      setNavigator();
+      reset({ "xss:blocklist:v2": [record("existing")] });
+      await store.addBlockRecords([
+        record("existing"),
+        record("new-a"),
+        record("new-a"),
+        record("new-b"),
+      ]);
+
+      const rows = data["xss:blocklist:v2"] as BlockRecord[];
+      assert.deepEqual(
+        rows.map((row) => row.id),
+        ["existing", "new-a", "new-b"],
+      );
+      assert.equal(setCalls.get("xss:blocklist:v2"), 1);
+    });
+
+    await t.test("fallback promise chain preserves concurrent records", async () => {
+      setNavigator();
+      reset({ "xss:blocklist:v2": [] });
+      await Promise.all(
+        Array.from({ length: 12 }, (_, index) => store.addBlockRecord(record(`f-${index}`))),
+      );
+      assert.equal((data["xss:blocklist:v2"] as BlockRecord[]).length, 12);
+    });
+
+    await t.test("Web Locks branch preserves concurrent records", async () => {
+      const locks = new FakeLockManager();
+      setNavigator(locks);
+      reset({ "xss:blocklist:v2": [] });
+      await Promise.all(
+        Array.from({ length: 12 }, (_, index) => store.addBlockRecord(record(`w-${index}`))),
+      );
+      assert.equal((data["xss:blocklist:v2"] as BlockRecord[]).length, 12);
+      assert.equal(locks.requests, 12);
+    });
+
+    await t.test("both stats stores accumulate concurrent increments", async () => {
+      setNavigator();
+      reset({
+        "xss:stats": { detections: 0, cacheHits: 0, blocks: 0, byLabel: {} },
+        mxga_stats_v1: { scanned: 0, hitPublic: 0, blocked: 0, firstUsedAt: 1 },
+      });
+      await Promise.all(
+        Array.from({ length: 10 }, () => [
+          store.bumpStats({ blocks: 1 }),
+          localStats.bumpStatBy("blocked", 1),
+        ]).flat(),
+      );
+      assert.equal((data["xss:stats"] as Stats).blocks, 10);
+      assert.equal((data.mxga_stats_v1 as LocalStats).blocked, 10);
+    });
+
+    await t.test("addBlockedMany deduplicates and updates the sync fast path", async () => {
+      setNavigator();
+      reset({ "xss:blocked": ["old"] });
+      const pending = blocklist.addBlockedMany(["new-a", "new-a", "new-b"]);
+      assert.equal(blocklist.isBlockedSync("new-a"), true);
+      assert.equal(blocklist.isBlockedSync("new-b"), true);
+      await pending;
+      assert.deepEqual(new Set(data["xss:blocked"] as string[]), new Set(["old", "new-a", "new-b"]));
+      assert.equal(setCalls.get("xss:blocked"), 1);
+    });
+
+    await t.test("strict batch surfaces set failures while the single wrapper does not", async () => {
+      setNavigator();
+      reset({ "xss:blocklist:v2": [] });
+      failingSetKey = "xss:blocklist:v2";
+      await assert.rejects(store.addBlockRecords([record("strict")]));
+      await assert.doesNotReject(store.addBlockRecord(record("legacy-wrapper")));
+      assert.deepEqual(data["xss:blocklist:v2"], []);
+    });
+  } finally {
+    if (previousChrome === undefined) delete root.chrome;
+    else root.chrome = previousChrome;
+    if (previousNavigator) Object.defineProperty(globalThis, "navigator", previousNavigator);
+    else delete (globalThis as { navigator?: unknown }).navigator;
+  }
+});


### PR DESCRIPTION
## 背景

本次改动只解决一件事：**自动处理里的「本地隐藏」应该成批执行，而不是逐个排队表演。**

现状是本地隐藏与 X 静音/拉黑共用同一条逐个排队路径，每一项都要占满 `AUTO_MIN_ACT_MS`=900ms 的可见节奏。X 动作有网络往返、需要逐个盯着成败，这个节奏是合理的；本地隐藏纯属本地 DOM + storage 操作，没有任何逐个等待的理由。一屏十几个命中，用户要干等十几秒才看完一次清理。

## 本次改动

### 主线：本地隐藏成批结算

- `drainAutoLoop` 每轮先把队列里所有本地隐藏项整批摘出，一次写处理记录、一次写屏蔽 ID、一次累加计数，然后统一收起 DOM。X 静音/拉黑完全不受影响，保留原有逐个节奏和就地徽标。
- `ui.ts` 新增 `markAutoBatchDone`：整批一次渲染、一次群飞动画，替代 N 次串行单飞。

### 附带：为了让批量写入不丢数据

批量路径把「N 次串行写」压成「1 次写」，这暴露了存储层原本就存在的并发问题，所以顺带修掉：

- `addBlockRecord` / `addBlocked` / `bumpStats` / `bumpStatBy` 都是「读全量 → 改 → 写回」且彼此不串行。同一 scan tick 并发触发时后写覆盖前写，表现为处理记录漏行、`xss:blocked` 快路径 ID 丢失、统计计数偏低。抽出 `withKeyLock`（优先 Web Locks，无 `LockManager` 时退化为按 key 的 Promise 链）统一串行化，原 `pendingLock` 收敛到同一实现。
- 新增 `addBlockRecords` / `addBlockedMany` 批量入口，锁内合并去重后只落一次 `storage.set`；单条 API 保留为薄封装，行为不变。
- `blocklist.ts` 用 `optimisticAdds` 保住 `isBlockedSync` 的同步快路径，`onChanged` 回填时不会把尚未落盘的 ID 冲掉。

### 附带：审计记录提交时机

顺带把记录提交挪到 drain 迭代开头（`enqueueAuto` 时快照），顺序固定为 记录 → 快路径 ID → resume 标记 → 不可逆的 X 动作。中途关页不再留下「已隐藏但没有恢复入口」的账号。

## 测试验证

- [x] `npm run compile`（extension，`tsc --noEmit`）通过
- [x] `npm test`（extension）32/32 通过。新增 `extension/test/store-batch.test.ts` 覆盖批量去重只写一次、Web Locks 与 Promise 链两条分支下 12 路并发不丢记录、两套统计并发累加、`isBlockedSync` 乐观可见、批量 API 抛错而单条封装吞错
- [ ] `npm run lint`：根 `lint` script 的路径参数不覆盖 `extension/`，本次未跑
- [x] 未提交任何密钥（`git status` 已确认）

## 风险与回滚

- 批量路径的 DOM 收起改为一次性，视觉节奏与逐个模式不同，建议在真实时间线上先确认体感是否符合预期。
- 记录先落盘、X 动作后执行，X 失败时靠 `updateBlockRecord` 补注「仅本地隐藏」；若该补注本身失败，记录会停留在乐观文案。
- 回滚：两个 commit 相互独立。`revert` 后一个即可恢复原逐个队列行为，存储层加锁可单独保留。

## 治理影响

- [x] 不削弱 GOVERNANCE.md 红线：仅改本地存储写入时序与 UI 结算节奏，未改判定门禁、未新增自动公开路径、未采集新数据。