### PR TITLE
fix(extension): hide every account in manual batch actions

### DIFF
--- a/extension/entrypoints/content.ts
+++ b/extension/entrypoints/content.ts
@@ -1,4 +1,5 @@
 import { hideAccountSurface } from "../lib/account-surface";
+import { findCurrentAuthorAnchor } from "../lib/current-author-anchor";
 import { autoEligible, capAutoTierAction } from "../lib/auto-policy";
 import { addBlocked, isBlockedSync, warm as warmBlocklist } from "../lib/blocklist";
 import { BRAND } from "../lib/brand";
@@ -364,8 +365,13 @@ export default defineContentScript({
       // X recycles article nodes: only hide via the captured anchor if it
       // still belongs to this account; otherwise use the tagged row, else
       // abort the DOM hide (the block itself is already recorded).
-      const anchor =
-        pendingActions.get(key)?.anchor ?? anchorByKey.get(key) ?? null;
+      // X virtualizes/recycles timeline rows. The cached scan anchor may still
+      // be connected but now represent a different author after an earlier
+      // item in a batch was hidden. Re-resolve by handle at execution time so
+      // progress/records cannot report success while hiding the wrong row (or
+      // no row at all).
+      const captured = pendingActions.get(key)?.anchor ?? anchorByKey.get(key) ?? null;
+      const anchor = findCurrentAuthorAnchor(document, sig.handle, captured) ?? captured;
       const art = articleOf(anchor);
       const sameAuthor =
         !!art && handleFromArticle(art)?.toLowerCase() === sig.handle.toLowerCase();

--- a/extension/lib/current-author-anchor.ts
+++ b/extension/lib/current-author-anchor.ts
@@ -1,0 +1,39 @@
+/** Return the current UserName block for a handle.
+ *
+ * X virtualizes timeline rows. A DOM element captured while scanning can stay
+ * connected after X has recycled it for another author, so callers must
+ * validate the author immediately before mutating the row.
+ */
+export function findCurrentAuthorAnchor(
+  root: ParentNode,
+  handle: string,
+  preferred?: HTMLElement | null,
+): HTMLElement | null {
+  const wanted = handle.toLowerCase();
+
+  const handleIn = (nameBlock: HTMLElement): string | undefined => {
+    for (const a of nameBlock.querySelectorAll<HTMLAnchorElement>('a[href^="/"]')) {
+      const parts = (a.getAttribute("href") ?? "").split("/").filter(Boolean);
+      if (parts.length === 1 && /^[A-Za-z0-9_]{1,15}$/.test(parts[0] ?? "")) {
+        return parts[0];
+      }
+    }
+    return undefined;
+  };
+
+  const nameBlockFor = (node: HTMLElement): HTMLElement | null => {
+    const own = node.matches('[data-testid="User-Name"]') ? node : null;
+    const block = own ?? node.closest<HTMLElement>('[data-testid="User-Name"]');
+    return block && handleIn(block)?.toLowerCase() === wanted ? block : null;
+  };
+
+  if (preferred && root.contains(preferred)) {
+    const current = nameBlockFor(preferred);
+    if (current) return current;
+  }
+
+  for (const nameBlock of root.querySelectorAll<HTMLElement>('[data-testid="User-Name"]')) {
+    if (handleIn(nameBlock)?.toLowerCase() === wanted) return nameBlock;
+  }
+  return null;
+}

--- a/extension/test/current-author-anchor.test.ts
+++ b/extension/test/current-author-anchor.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseHTML } from "linkedom";
+import { findCurrentAuthorAnchor } from "../lib/current-author-anchor";
+
+test("re-resolves a recycled cached anchor by the current author", () => {
+  const { document, window } = parseHTML(`
+    <main>
+      <article id="row-a"><div data-testid="User-Name"><a href="/alice">@alice</a></div></article>
+      <article id="row-b"><div data-testid="User-Name"><a href="/bob">@bob</a></div></article>
+    </main>
+  `);
+  Object.assign(globalThis, { HTMLElement: window.HTMLElement });
+
+  const stale = document.querySelector<HTMLElement>("#row-a [data-testid=User-Name]");
+  const current = findCurrentAuthorAnchor(document, "bob", stale);
+
+  assert.equal(current?.closest("article")?.id, "row-b");
+});
+
+test("does not return a connected node that was recycled for another author", () => {
+  const { document, window } = parseHTML(`
+    <main><article><div data-testid="User-Name"><a href="/bob">@bob</a></div></article></main>
+  `);
+  Object.assign(globalThis, { HTMLElement: window.HTMLElement });
+
+  const current = findCurrentAuthorAnchor(document, "alice");
+  assert.equal(current, null);
+});


### PR DESCRIPTION
## Summary

Fixes a race with X timeline virtualization during manual bulk hide actions. The UI could report all selected accounts as processed while only the first account was visually hidden because later actions reused stale DOM anchors.

## Changes

- Re-resolve the current `UserName` DOM block by handle immediately before hiding.
- Validate cached anchors before mutating the row.
- Add regression tests for recycled/stale anchors.

## Verification

- `npm test` in `extension/` — 27/27 passing
- `npm run build` in `extension/` — Chrome MV3 production build passing
- Manual verification — processed two accounts in the web extension; both were hidden correctly