### PR TITLE
fix(firefox): 修复 x.com 权限授权死循环与原生静音/拉黑失败

### DIFF
--- a/extension/entrypoints/options/App.tsx
+++ b/extension/entrypoints/options/App.tsx
@@ -897,6 +897,20 @@ function Toggle({
 }
 
 const X_ORIGINS = ["*://x.com/*", "*://twitter.com/*"];
+const GH_ORIGINS = ["https://github.com/*"];
+
+// Firefox's chrome.* compatibility shim does NOT promisify
+// permissions.request / permissions.contains — calling them without a callback
+// returns `undefined`, so `await`ing them yields a falsy value and a successful
+// grant is wrongly treated as denied (the exact "未授权访问 x.com" loop, even
+// after the user clicks Allow). The native `browser.*` API is fully
+// promise-based and reliable, so prefer it on Firefox and fall back to chrome.*
+// on Chromium builds.
+const perms = ((globalThis as any).browser?.permissions ??
+  (globalThis as any).chrome.permissions) as {
+  contains: (p: any) => Promise<boolean>;
+  request: (p: any) => Promise<boolean>;
+};
 
 const ACTION_MODES: {
   value: ActionMode;
@@ -941,8 +955,26 @@ function isMobileApplePlatform(): boolean {
 async function ensureXPermission(): Promise<boolean> {
   if (import.meta.env.SAFARI) return true;
   try {
-    if (await chrome.permissions.contains({ origins: X_ORIGINS })) return true;
-    return await chrome.permissions.request({ origins: X_ORIGINS });
+    // Firefox REQUIRES permissions.request() to be called synchronously from
+    // a user input handler. Any await *before* it (e.g. contains()) lets the
+    // browser drop the user-gesture token, and request() throws:
+    //   "permissions.request may only be called from a user input handler"
+    //
+    // If the permission is already granted, request() returns true instantly
+    // without showing a dialog, so calling it unconditionally is harmless.
+    // The only ground truth is contains(), which we check afterward.
+    // The return value is intentionally ignored: request() can resolve to
+    // false (or to `undefined` under Firefox's chrome.* shim) even when the
+    // grant succeeded. We only await it to keep a possible rejection from
+    // surfacing as an unhandled promise error.
+    try {
+      await perms.request({ origins: X_ORIGINS });
+    } catch {
+      // Firefox throws "permissions.request may only be called from a user
+      // input handler" when the gesture token was already consumed. The grant
+      // may still have gone through, so fall through to contains().
+    }
+    return await perms.contains({ origins: X_ORIGINS });
   } catch {
     return false;
   }
@@ -1168,16 +1200,31 @@ function WhitelistApplySection({ edgeBase }: { edgeBase: string }) {
   const ghLogin = async () => {
     setMsg(null);
     try {
+      // Same two Firefox pitfalls as ensureXPermission():
+      //   1. permissions.request() must be called SYNCHRONOUSLY from the user
+      //      input handler — an `await` before it (here: the data_collection
+      //      request) drops the user-gesture token and the second request()
+      //      throws "permissions.request may only be called from a user input
+      //      handler".
+      //   2. request()'s return value is NOT reliable — it can return false
+      //      even for already-granted origins, which produced the exact
+      //      "未授权访问 …" loop. contains() is the only ground truth.
+      //
+      // So: fire every request() synchronously, then judge with contains().
+      const pending: Promise<unknown>[] = [];
       if (import.meta.env.BROWSER === "firefox") {
-        const dataGranted = await chrome.permissions.request({
-          data_collection: ["authenticationInfo", "personallyIdentifyingInfo"],
-        } as chrome.permissions.Permissions & { data_collection: string[] });
-        if (!dataGranted) {
-          setMsg({ text: "未授权白名单申请所需的数据传输权限。", ok: false });
-          return;
-        }
+        pending.push(
+          Promise.resolve(
+            perms.request({
+              data_collection: ["authenticationInfo", "personallyIdentifyingInfo"],
+            } as any),
+          ).catch(() => undefined),
+        );
       }
-      const granted = await chrome.permissions.request({ origins: ["https://github.com/*"] });
+      pending.push(Promise.resolve(perms.request({ origins: GH_ORIGINS })).catch(() => undefined));
+      await Promise.all(pending);
+
+      const granted = await perms.contains({ origins: GH_ORIGINS });
       if (!granted) {
         setMsg({ text: "未授权访问 github.com——一键登录需要该权限（仅用于 GitHub 配对登录）。", ok: false });
         return;

--- a/extension/lib/x-action.ts
+++ b/extension/lib/x-action.ts
@@ -18,6 +18,10 @@ export interface XActionAttempt {
   status?: number;
   retryable?: boolean;
   retryAfterMs?: number;
+  /** Human-readable failure cause. Diagnostic only — never sent anywhere.
+   *  Without this a failed mute/block is completely silent (the caller just
+   *  returns false), which makes "auto-block does nothing" undebuggable. */
+  reason?: string;
 }
 
 // X web's long-standing public bearer (same one the site itself sends).
@@ -41,23 +45,33 @@ const RATE_LIMIT_COOLDOWN_MS = 45_000;
 const TRANSIENT_COOLDOWN_MS = 8_000;
 const LS_LAST_ACTION = "mxga:last-x-action";
 const LS_ACTION_ROUND = "mxga:x-action-round";
-const LOCK_NAME = "mxga-x-action";
 
 interface ActionRound {
   count: number;
   cooldownUntil: number;
 }
 
-type LockCapableNavigator = Navigator & {
-  locks?: {
-    request<T>(name: string, callback: () => T | Promise<T>): Promise<T>;
-  };
-};
-
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+/** Safely stringify a thrown value. Reading `.message` on an object from a
+ *  foreign JS compartment can itself throw in Firefox, so guard both the
+ *  property read and the String() coercion. */
+function errText(e: unknown): string {
+  try {
+    const m = (e as { message?: unknown } | null)?.message;
+    if (typeof m === "string" && m) return m;
+    return String(e);
+  } catch {
+    return "unknown error";
+  }
+}
+
 function ct0() {
-  return document.cookie.match(/ct0=([^;]+)/)?.[1] ?? "";
+  try {
+    return document.cookie.match(/ct0=([^;]+)/)?.[1] ?? "";
+  } catch {
+    return "";
+  }
 }
 
 function apiOrigin() {
@@ -174,9 +188,87 @@ async function waitForSlot() {
   setStorageNumber(LS_LAST_ACTION, Date.now());
 }
 
+// Serialization for X write actions.
+//
+// We deliberately do NOT use the Web Locks API (navigator.locks). In a Firefox
+// content script the LockManager belongs to the page's JS compartment, so
+// `locks.request()` returns a FOREIGN-compartment Promise. Every way of
+// consuming such a promise — `await`, `.then()`, `.catch()`, and even
+// `Promise.resolve()` — has to read its `then` property, which throws:
+//     Error: Permission denied to access property "then"
+// Promise.resolve() does NOT help: it only short-circuits when the value's
+// constructor is the *same* Promise object, which is false across
+// compartments. It just converts the synchronous throw into a rejection that
+// then surfaces as "[MXGA] 自动拉黑处理异常 … property \"then\"".
+//
+// A local promise chain gives the same serialization inside this context.
+// Cross-tab pacing is already handled by waitForSlot(), which coordinates
+// through localStorage timestamps.
+let mutexChain: Promise<unknown> = Promise.resolve();
+
 async function withLock<T>(fn: () => Promise<T>): Promise<T> {
-  const locks = (navigator as LockCapableNavigator).locks;
-  return locks ? locks.request(LOCK_NAME, fn) : fn();
+  const run = mutexChain.then(fn, fn);
+  // Keep the chain alive across failures (otherwise one rejection would poison
+  // every later action); the caller still sees `run`'s own rejection.
+  mutexChain = run.catch(() => {});
+  return run;
+}
+
+interface XhrResult {
+  status: number;
+  header(name: string): string | null;
+}
+
+/**
+ * POST via XMLHttpRequest rather than fetch.
+ *
+ * fetch() in a Firefox content script can return a Promise created in the
+ * page's JS compartment, which cannot be consumed (see withLock above —
+ * reading `.then` throws "Permission denied to access property \"then\"").
+ * XHR is callback-based, so we construct the Promise ourselves, in OUR
+ * compartment, and never touch a foreign one.
+ */
+function xhrPost(
+  url: string,
+  headers: Record<string, string>,
+  body: string,
+  timeoutMs: number,
+): Promise<XhrResult> {
+  return new Promise<XhrResult>((resolve, reject) => {
+    let xhr: XMLHttpRequest;
+    try {
+      xhr = new XMLHttpRequest();
+    } catch (e) {
+      reject(e);
+      return;
+    }
+    try {
+      xhr.open("POST", url, true);
+      // Send the x.com session cookies (ct0 among them). Same-origin from the
+      // content script's point of view, so no CORS preflight.
+      xhr.withCredentials = true;
+      xhr.timeout = timeoutMs;
+      for (const [k, v] of Object.entries(headers)) xhr.setRequestHeader(k, v);
+      xhr.onload = () =>
+        resolve({
+          status: xhr.status,
+          header: (name: string) => {
+            try {
+              return xhr.getResponseHeader(name);
+            } catch {
+              return null;
+            }
+          },
+        });
+      xhr.onerror = () => reject(new Error("网络错误"));
+      xhr.ontimeout = () => reject(new Error(`请求超时（${timeoutMs}ms）`));
+      xhr.onabort = () => reject(new Error("请求被中止"));
+      xhr.send(body);
+    } catch (e) {
+      // e.g. the page CSP blocks the request, or open()/send() throws.
+      reject(e);
+    }
+  });
 }
 
 /** Single first-party mute/block call. Returns ok/false + retry hints. */
@@ -187,39 +279,58 @@ async function rawAction(
 ): Promise<XActionAttempt> {
   try {
     const csrf = ct0();
-    if (!csrf) return { ok: false, retryable: false };
+    if (!csrf) {
+      return {
+        ok: false,
+        retryable: false,
+        reason: "未取到 ct0（未登录 X，或浏览器阻止了 content script 读取 cookie）",
+      };
+    }
     const screenName = normalizeHandle(handle);
     const body = new URLSearchParams();
     // Prefer the immutable numeric user_id: handles rename, and a wrongly
     // extracted pseudo-handle 404s silently — the id never lies.
     if (userId && /^\d+$/.test(userId)) body.set("user_id", userId);
     else if (screenName) body.set("screen_name", screenName);
-    else return { ok: false, retryable: false };
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 15_000);
-    const res = await fetch(`${apiOrigin()}${ENDPOINT[kind]}`, {
-      method: "POST",
-      credentials: "include",
-      signal: controller.signal,
-      headers: {
-        authorization: FALLBACK_X_BEARER,
-        "x-csrf-token": csrf,
-        "x-twitter-auth-type": "OAuth2Session",
-        "x-twitter-active-user": "yes",
-        "content-type": "application/x-www-form-urlencoded",
-      },
-      body: body.toString(),
-    }).finally(() => clearTimeout(timer));
+    else
+      return {
+        ok: false,
+        retryable: false,
+        reason: "既无合法 user_id 也无 screen_name，无法定位账号",
+      };
+    let res: XhrResult;
+    try {
+      res = await xhrPost(
+        `${apiOrigin()}${ENDPOINT[kind]}`,
+        {
+          authorization: FALLBACK_X_BEARER,
+          "x-csrf-token": csrf,
+          "x-twitter-auth-type": "OAuth2Session",
+          "x-twitter-active-user": "yes",
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body.toString(),
+        15_000,
+      );
+    } catch (e) {
+      return { ok: false, retryable: true, reason: `请求异常：${errText(e)}` };
+    }
     const status = res.status;
+    const ok = status >= 200 && status < 300;
+    const retryable =
+      status === 408 || status === 425 || status === 429 || status >= 500;
     return {
-      ok: res.ok,
+      ok,
       status,
-      retryAfterMs: parseRetryAfterMs(res.headers.get("retry-after")),
-      retryable:
-        status === 408 || status === 425 || status === 429 || status >= 500,
+      retryAfterMs: parseRetryAfterMs(res.header("retry-after")),
+      retryable,
+      // 403/401 from X almost always means the CSRF token or session is not
+      // accepted (or X now wants a transaction id) — surface it instead of
+      // failing silently.
+      reason: ok ? undefined : `X 返回 HTTP ${status}`,
     };
-  } catch {
-    return { ok: false, retryable: true };
+  } catch (e) {
+    return { ok: false, retryable: true, reason: `请求异常：${errText(e)}` };
   }
 }
 


### PR DESCRIPTION
Firefox 下两个相互独立的兼容性问题：

1) 选项页反复提示「未授权访问 x.com」
   - Firefox 的 chrome.* 兼容层不会 promisify permissions.request / permissions.contains：不传回调时返回 undefined，await 后恒为假值， 于是已经授权的权限仍被判成未授权。改为优先使用原生 browser.permissions，仅在 Chromium 回退到 chrome.permissions。
   - Firefox 要求 permissions.request() 必须在用户输入处理函数中同步 调用。原先先 await contains() 会消耗用户手势令牌，导致 request() 抛出 "permissions.request may only be called from a user input handler"。改为同步发起 request()（返回值不可信，仅吞掉其 rejection），最终一律以 contains() 为准。
   - ghLogin() 中的 GitHub origin 与 data_collection 授权存在同样问题， 一并改为同步发起后用 contains() 判定。

2) 自动拉黑/静音抛 Permission denied to access property "then"
   - content script 与页面 JS 属于不同 compartment，页面 compartment 产生的 Promise 无法被消费（读取其 then 属性即抛错）。 navigator.locks.request() 与 fetch() 都可能返回这类 Promise； 且 Promise.resolve() 无法规避——跨 compartment 时 constructor 不是同一个 Promise 对象，仍会走 thenable 分支去读取 then。
   - 序列化改用本地 Promise 链（跨标签页节流本就由 waitForSlot() 基于 localStorage 时间戳负责）；
   - POST 改用 XMLHttpRequest：回调式 API，Promise 由我们自己在 本 compartment 内构造，全程不触碰外来 Promise。
   - XActionAttempt 增加可选 reason 字段，失败原因不再静默丢失。

## 背景

## 本次改动

## 测试验证
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm lint`
- [x] 未提交任何密钥（`git status` 已确认）

## 风险与回滚

## 治理影响
- [x] 不削弱 GOVERNANCE.md 红线（无自动公开 / 范围 / 申诉 / 隐私 / 被动姿态）

## 关联 Issue
<!-- Closes #123 / Related #123 -->
