### PR TITLE
ZUO-14: record appeal review for GitHub #405

### DIFF
--- a/docs/goal-open-issues-2026-08-26.json
+++ b/docs/goal-open-issues-2026-08-26.json
@@ -1,0 +1,39 @@
+{
+  "run_at": "2026-09-13T12:53:49+08:00",
+  "scope": "open appeal issue #405 (single-account issue; no other open GitHub issues found in the sweep)",
+  "source": {
+    "github_repo": "https://github.com/foru17/make-x-great-again",
+    "github_issue": "https://github.com/foru17/make-x-great-again/issues/405",
+    "production_api": "https://x.zuoluo.tv",
+    "governance": "GOVERNANCE.md"
+  },
+  "verification": {
+    "x_profile": "The live X profile resolves @EricWongly to UID 1675836276648361985; it is available, shows Eric Wong, joined 2023-07-03, reports 45 posts, 6 followers, 57 following, and has an empty bio. The profile page currently renders no original posts. No repeatable commercial spam or porn-advertising-bot evidence was found.",
+    "pre_decision": "No matching account was found in /v1/check, /v1/admin/blacklist, /v1/admin/queue, /v1/admin/whitelist, or the latest data-mirror blacklist and whitelist snapshots.",
+    "post_decision": "Authenticated admin whitelist returned the normalized handle ericwongly with rowid 959041 and status whitelisted; review_log contains audit ID 757916 with action whitelist_add. /v1/whitelist returned the UID, /v1/check returned no hit, and the current lite/shards artifacts contain neither the UID nor the handle.",
+    "artifact_version": "v-_____f_______f_-174429",
+    "artifact_generated_at": 1789275058024,
+    "artifact_count": 174429,
+    "rowid_note": "The rowid was recovered by decoding the authenticated admin whitelist endpoint's limit=1 nextBefore cursor [1789275084344,1789275084344,959041]; it was not guessed."
+  },
+  "records": [
+    {
+      "issue": 405,
+      "handle": "EricWongly",
+      "decision": "whitelisted",
+      "uid": "1675836276648361985",
+      "rowid": 959041,
+      "audit_id": 757916,
+      "audit_action": "whitelist_add",
+      "github_comment_id": 5651240588,
+      "result": "completed",
+      "evidence": "The current public X profile resolves the submitted UID exactly and shows an available account with no repeatable commercial spam or porn-advertising-bot evidence. Evidence is insufficient for a blacklist under the project scope.",
+      "sources": [
+        "https://x.com/EricWongly"
+      ],
+      "check_hit": false,
+      "whitelist_present": true,
+      "artifact_present": false
+    }
+  ]
+}

--- a/docs/goal-open-issues-2026-08-26.json
+++ b/docs/goal-open-issues-2026-08-26.json
@@ -14,7 +14,23 @@
     "artifact_version": "v-_____f_______f_-174429",
     "artifact_generated_at": 1789275058024,
     "artifact_count": 174429,
-    "rowid_note": "The rowid was recovered by decoding the authenticated admin whitelist endpoint's limit=1 nextBefore cursor [1789275084344,1789275084344,959041]; it was not guessed."
+    "rowid_note": "The rowid was recovered by decoding the authenticated admin whitelist endpoint's limit=1 nextBefore cursor [1789275084344,1789275084344,959041]; it was not guessed.",
+    "external_actions": {
+      "github_comment_edited": [5651240588],
+      "github_comment_deleted": [
+        {
+          "id": 5651273230,
+          "result": "already_absent_at_verification"
+        }
+      ],
+      "github_issue_closed": [
+        {
+          "issue": 405,
+          "state": "closed",
+          "reason": "completed"
+        }
+      ]
+    }
   },
   "records": [
     {
@@ -28,7 +44,7 @@
       "audit_action": "whitelist_add",
       "github_comment_id": 5651240588,
       "result": "completed",
-      "evidence": "The current public X profile resolves the submitted UID exactly and shows an available account with no repeatable commercial spam or porn-advertising-bot evidence. Evidence is insufficient for a blacklist under the project scope.",
+      "evidence": "The account was not listed before review; the current public X profile resolves the submitted UID exactly and shows no repeatable commercial spam or porn-advertising-bot evidence. It was registered preventively on the whitelist.",
       "sources": [
         "https://x.com/EricWongly"
       ],

--- a/docs/goal-open-issues-2026-08-26.json
+++ b/docs/goal-open-issues-2026-08-26.json
@@ -8,9 +8,9 @@
     "governance": "GOVERNANCE.md"
   },
   "verification": {
-    "x_profile": "The live X profile resolves @EricWongly to UID 1675836276648361985; it is available, shows Eric Wong, joined 2023-07-03, reports 45 posts, 6 followers, 57 following, and has an empty bio. The profile page currently renders no original posts. No repeatable commercial spam or porn-advertising-bot evidence was found.",
+    "x_profile": "The live X profile resolves @EricWongly to UID 1675836276648361985; it is available, shows Eric Wong, joined 2023-07-03, reports 45 posts, 6 followers, 57 following, and has an empty bio. The logged-out profile view did not expose timeline entries. No repeatable commercial spam or porn-advertising-bot evidence was found.",
     "pre_decision": "No matching account was found in /v1/check, /v1/admin/blacklist, /v1/admin/queue, /v1/admin/whitelist, or the latest data-mirror blacklist and whitelist snapshots.",
-    "post_decision": "Authenticated admin whitelist returned the normalized handle ericwongly with rowid 959041 and status whitelisted; review_log contains audit ID 757916 with action whitelist_add. /v1/whitelist returned the UID, /v1/check returned no hit, and the current lite/shards artifacts contain neither the UID nor the handle.",
+    "post_decision": "Because no pre-existing blacklist or pending row was found, the authenticated admin whitelist created a preventive registration for normalized handle ericwongly with rowid 959041 and status whitelisted; review_log contains audit ID 757916 with action whitelist_add. /v1/whitelist returned the UID, /v1/check returned no hit, and the current lite/shards artifacts contain neither the UID nor the handle.",
     "artifact_version": "v-_____f_______f_-174429",
     "artifact_generated_at": 1789275058024,
     "artifact_count": 174429,
@@ -21,6 +21,7 @@
       "issue": 405,
       "handle": "EricWongly",
       "decision": "whitelisted",
+      "was_listed_before": false,
       "uid": "1675836276648361985",
       "rowid": 959041,
       "audit_id": 757916,


### PR DESCRIPTION
Closes ZUO-14

记录 GitHub #405（@EricWongly）的单账号申诉复核结果：

- 当前 X 公开资料未发现可重复的商业垃圾或色情广告 bot 证据。
- 生产账号已按 UID `1675836276648361985` 加入 `whitelisted`，审计 ID 为 `757916`，rowid 为 `959041`。
- GitHub 标准回复已发布，评论 ID 为 `5651240588`，Issue 已以 completed 关闭。
- `jq empty docs/goal-open-issues-2026-08-26.json` 与 `git diff --check` 已通过。